### PR TITLE
Create landing page web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To build & run Saber with __Docker__:
 
 There are currently two endpoints, `/annotate/text` and `/annotate/pmid`. Both expect a `POST` request with a `json` payload, e.g.:
 
-```
+```json
 {
   "text": "The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53."
 }
@@ -147,7 +147,7 @@ There are currently two endpoints, `/annotate/text` and `/annotate/pmid`. Both e
 
 Or:
 
-```
+```json
 {
   "pmid": 11835401
 }
@@ -155,9 +155,12 @@ Or:
 
 For example, running the web-service locally and using `cURL`:
 
+```bash
+curl -X POST 'http://localhost:5000/annotate/text' \
+--data '{"text": "The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53."}'
 ```
-curl -XPOST --data '{"text": "The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53."}' 'http://localhost:5000/annotate/text'
-```
+
+Full documentation for the Saber API can be found [here]('http://localhost:5000/annotate/text').
 
 #### Command line tool
 

--- a/saber/app.py
+++ b/saber/app.py
@@ -1,13 +1,22 @@
 """Simple web service which exposes Saber's functionality via a RESTful API.
 """
 #!/usr/bin/env python3
-from flask import request
-from flask import jsonify
 from flask import Flask
-app = Flask(__name__)
+from flask import jsonify
+from flask import redirect
+from flask import render_template
+from flask import request
 
 from .utils import app_utils
 from .config import Config
+
+app = Flask(__name__)
+
+@app.route('/')
+def serve_api_docs():
+    """Flask view that redirects to the Saber API docs from route '/'.
+    """
+    return redirect('https://baderlab.github.io/saber-api-docs/')
 
 @app.route('/annotate/text', methods=['POST'])
 def annotate_text():
@@ -91,6 +100,6 @@ if __name__ == '__main__':
     # Load the pre-trained models
     ENTITIES = {'ANAT': False, 'CHED': False, 'DISO': False, 'LIVB': False,
                 'PRGE': True, 'TRIG': False}
-    MODELS = app_utils.load_models(ENTITIES)
+    # MODELS = app_utils.load_models(ENTITIES)
 
     app.run(host='0.0.0.0')


### PR DESCRIPTION
This begins the process of fleshing out the web service. The Flask web app now routes all requests to `'/'` to API documentation built with [Slate](https://github.com/lord/slate).

Closes #8.