### PR TITLE
Additionally save config file when saving a model

### DIFF
--- a/saber/sequence_processor.py
+++ b/saber/sequence_processor.py
@@ -156,8 +156,7 @@ class SequenceProcessor(object):
         if filepath is None:
             filepath = generic_utils.get_pretrained_model_dir(self.config)
 
-        # create the pretrained model folder (if it does not exist)
-        generic_utils.make_dir(os.path.join(filepath))
+        generic_utils.make_dir(filepath)
         # create filepaths
         weights_filepath = os.path.join(filepath, 'model_weights.hdf5')
         attributes_filepath = os.path.join(filepath, 'model_attributes.pickle')
@@ -173,6 +172,8 @@ class SequenceProcessor(object):
         self.model.model[model].save_weights(weights_filepath)
         # save attributes
         pickle.dump(model_attributes, open(attributes_filepath, 'wb'))
+        # save config file
+        self.config.save(filepath)
 
         if compress:
             generic_utils.compress_model(filepath)


### PR DESCRIPTION
When a model is saved using `SequenceProcessor.save()`, the configuration used to train that model as an `.ini` file is saved in the saved model folder.

This simply involved adding a call to `Config.save()`.

Closes #26.