### PR TITLE
Implement transfer learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ All hyper-parameters are specified in a configuration file. The configuration fi
 (saber) $ python -m saber.train --config_filepath path/to/config.ini
 ```
 
-If not specified, the default configuration file at `saber/config.ini` is used.
+> If not specified, the default configuration file at `saber/config.ini` is used.
 
-Alternatively, you can supply arguments at the command line. Each command line argument has an identical name to those found in `saber/config.ini`. For example:
+Alternatively, you can supply arguments at the command line. Each command line argument has a name identical to those found in `saber/config.ini`. For example:
 
 ```bash
 (saber) $ python -m saber.train --dataset_folder path/to/dataset --k_folds 10
@@ -215,29 +215,21 @@ sp.fit()
 ```
 #### Juypter notebooks
 
-First, install [JupyterLab](https://github.com/jupyterlab/jupyterlab) (make sure to activate your virtual environment first if you created one):
+First, install [JupyterLab](https://github.com/jupyterlab/jupyterlab) by following the instructions [here](https://github.com/jupyterlab/jupyterlab#installation) (make sure to activate your virtual environment first if you created one!
 
-```bash
-# If you use pip, you can install it as
-(saber) $ pip install jupyterlab
-
-# If you use conda, you can install as
-(saber) $ conda install -c conda-forge jupyterlab
-```
-
-> Note, you only need to install this once!
-
-This is a temporary work-around, but you must also `pip install .` for the notebooks to work:
+This is a _temporary_ work-around, but you must also run:
 
 ```
-(saber) $ pip install .
+(saber) $ pip install --upgrade .
 ```
 
-Then `cd` into `saber` and run:
+for the notebooks to work. Finally, run:
 
 ```
 (saber) $ jupyter lab
 ```
+
+> Note: if you activated a virtual enviornment make sure you see **Python [conda env:saber]** in the top right of the Jupyter notebook.
 
 Check out the `lightning_tour.ipynb` notebook for an overview.
 
@@ -279,7 +271,7 @@ To use [GloVe](https://nlp.stanford.edu/projects/glove/) embeddings, just conver
 
 ## Running tests
 
-Sabers test suite can be found in `Saber/saber/tests`. In order to run the tests, you'll usually want to clone the repository locally. Make sure to install all required development dependencies defined in the ``requirements.txt`` (see [Installation](#Installation) for more help). Additionally, you will need to install ``pytest``:
+Sabers test suite can be found in `saber/tests`. In order to run the tests, you'll usually want to clone the repository locally. Make sure to install all required development dependencies defined in the ``requirements.txt`` (see [Installation](#Installation) for more help). Additionally, you will need to install ``pytest``:
 
 ```bash
 (saber) $ pip install pytest

--- a/README.md
+++ b/README.md
@@ -184,24 +184,35 @@ Would overwrite the arguments for `dataset_folder` and `k_folds` found in the co
 
 #### Python module
 
-Saber exposes its functionality through the `SequenceProcessor` class. Here is a simple example where we load a pre-trained model and use it to annotate raw text for protein and gene entities.
+Saber exposes its functionality through the `SequenceProcessor` class. Here is just about everything Saber does in one script:
 
 ```python
 from saber.sequence_processor import SequenceProcessor
 
-# Create a SequenceProcessor object, which coordinates training/prediction/loading of models and datasets
+# First, create a SequenceProcessor object, which exposes Sabers functionality
 sp = SequenceProcessor()
 
-# Load the protein and gene entity model
-sp.load('path/to/pretrained_models/PRGE')
+# Load a dataset and create a model (provide a list of datasets to use multi-task learning!)
+sp.load_dataset('path/to/datasets/GENIA')
+sp.create_model()
 
-# Text to annotate
-raw_text = 'The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.'
+# Train and save a model
+sp.fit()
+sp.save('pretrained_models/GENIA')
+
+# Load a model
+del sp
+sp = SequenceProcessor()
+sp.load('pretrained_models/CRAFT')
 
 # Perform prediction on raw text, get resulting annotation
+raw_text = 'The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.'
 annotation = sp.annotate(raw_text)
-```
 
+# Use transfer learning to continue training on a new dataset
+sp.load_dataset('path/to/datasets/CRAFT')
+sp.fit()
+```
 #### Juypter notebooks
 
 First, install [JupyterLab](https://github.com/jupyterlab/jupyterlab) (make sure to activate your virtual environment first if you created one):

--- a/saber/config.py
+++ b/saber/config.py
@@ -188,7 +188,7 @@ class Config(object):
                                   "matching and 'exact' for exact-boundary matching."))
         parser.add_argument('--dataset_folder', required=False, nargs='*',
                             help=("Path to the dataset folder. Expects a file 'train.*' to be "
-                                  "present. Optionally, 'valid.*' and 'train.*' may be provided."
+                                  "present. Optionally, 'valid.*' and 'test.*' may be provided. "
                                   "Multiple datasets can be provided, sperated by a space"))
         parser.add_argument('--debug', required=False, action='store_true',
                             help=('If provided, only a small proportion of the dataset, and any '
@@ -198,7 +198,7 @@ class Config(object):
                                   'certain optimizers this value is ignored. Defaults to 0.'))
         parser.add_argument('--dropout_rate', required=False, nargs=3, type=float,
                             metavar=('input', 'output', 'recurrent'),
-                            help=('Expectes three values, seperated by a space, which specify the '
+                            help=('Expects three values, seperated by a space, which specify the '
                                   'fraction of units to drop for input, output and recurrent '
                                   'connections respectively. Values must be between 0 and 1.'))
         parser.add_argument('--fine_tune_word_embeddings', required=False, action='store_true',
@@ -207,7 +207,7 @@ class Config(object):
         parser.add_argument('--grad_norm', required=False, type=float,
                             help='Tau threshold value for gradient normalization, defaults to 1.')
         parser.add_argument('--k_folds', required=False, type=int,
-                            help=('Number of folds to preform in cross-validation, defaults to 5.'
+                            help=('Number of folds to preform in cross-validation, defaults to 5. '
                                   "Argument is ignored if 'test.*' file present in dataset_folder"))
         parser.add_argument('--learning_rate', required=False, type=float,
                             help=('float >= 0. Learning rate. Note that for certain optimizers '
@@ -216,29 +216,34 @@ class Config(object):
                             help=('Integer. Number of epochs to train the model. An epoch is an '
                                   'iteration over all data provided.'))
         parser.add_argument('--model_name', required=False, type=str,
-                            help=('Which model architecture to use. Currently, only MT-LSTM-CRF is '
-                                  'provided.'))
+                            help="Which model architecture to use. Must be one of ['MT-LSTM-CRF, ']")
         parser.add_argument('--optimizer', required=False, type=str,
                             help=("Name of the optimization function to use during training. All "
-                                  'optimizers implemented in Keras are supported. Defaults to '
+                                  "optimizers implemented in Keras are supported. Defaults to "
                                   "'nadam'."))
         parser.add_argument('--output_folder', required=False, type=str,
-                            help='Path to the top-level of the directory to save all output files.')
+                            help='Path to top-level directory to save all output files.')
         parser.add_argument('--pretrained_model_weights', required=False, type=str, help='TODO')
         parser.add_argument('--replace_rare_tokens', required=False, action='store_true',
                             help=('If True, word types that occur less than 1 time in the training '
                                   'dataset will be replaced with a special unknown token.'))
-        parser.add_argument('--save_model', required=False, action='store_true', help='TODO')
-        parser.add_argument('--tensorboard', required=False, action='store_true', help='TODO')
+        parser.add_argument('--save_model', required=False, action='store_true',
+                            help=('True if the model should be saved when training is complete. '
+                                  'Defaults to False.'))
+        parser.add_argument('--tensorboard', required=False, action='store_true',
+                            help=('True if tensorboard logs should be saved during training (note '
+                                  'these can be very large). Defaults to False.'))
         parser.add_argument('--word_embed_dim', required=False, type=int,
                             help='Dimension of dense embeddings to be learned for each word.')
         parser.add_argument('--pretrained_embeddings', required=False, type=str,
-                            help='Filepath to pretrained word embeddings.')
+                            help='Filepath to pre-trained word embeddings.')
         parser.add_argument('--train_model', required=False, action='store_true', help='TODO')
         parser.add_argument('--variational_dropout', required=False, action='store_true',
-                            help=('Pass this flag if variational dropout should be used. NOTE THAT'
-                                  'THIS IS TEMPORARY'))
-        parser.add_argument('--verbose', required=False, action='store_true', help='TODO')
+                            help=('Pass this flag if variational dropout should be used. NOTE THAT '
+                                  'THIS IS TEMPORARY.'))
+        parser.add_argument('--verbose', required=False, action='store_true',
+                            help=('True to display more information, such has model details, '
+                                  'hyperparameters, and architecture. Defaults to False.'))
 
         # parse cli args, return dictionary representation of these args
         cli_args = parser.parse_args()

--- a/saber/config.py
+++ b/saber/config.py
@@ -22,7 +22,7 @@ class Config(object):
         filepath (str): path to a .ini file, defaults to ./config.ini
         cli (bool): True if command line arguments will be supplied, defaults to False.
     """
-    def __init__(self, filepath='./config.ini', cli=False):
+    def __init__(self, filepath='config.ini', cli=False):
         self.log = logging.getLogger(__name__)
         # filepath to config file
         self.filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), filepath)
@@ -250,7 +250,7 @@ class Config(object):
 
         Saves a config.ini file at filepath, containing the harmonized arguments sourced from the
         original config file at `self.config` and any arguments supplied at the command line.
-    
+
         Args:
             dir_path (str): directory path to save the config.ini file.
         """

--- a/saber/config.py
+++ b/saber/config.py
@@ -7,6 +7,7 @@ import logging
 import os
 
 from .preprocessor import Preprocessor
+from .utils import generic_utils
 
 # TODO: Some arguments still need help strings written
 
@@ -15,7 +16,7 @@ class Config(object):
 
     Conatains methods for parsing arguments supplied at the command line or in a python ConfigParser
     object. Deals with harmonizing arguments from both of these sources. Each arguments value is
-    assigned to an instance variable.
+    assigned to an instance attribute.
 
     Args:
         filepath (str): path to a .ini file, defaults to ./config.ini
@@ -23,7 +24,6 @@ class Config(object):
     """
     def __init__(self, filepath='./config.ini', cli=False):
         self.log = logging.getLogger(__name__)
-
         # filepath to config file
         self.filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), filepath)
         # parse args provided in configuration file
@@ -31,16 +31,16 @@ class Config(object):
         # parse cli arguments (if they exist)
         self.cli_args = self._parse_cli_args() if cli else {}
         # harmonize cli and config arguments and apply post processing
-        self.args = self._process_args(self.cli_args)
+        self._process_args(self.cli_args)
 
     def _parse_config(self, filepath):
         """Returns a parsed configparser object for config file at 'filepath'.
 
         Args:
-            filepath: filepath to .ini config file
+            filepath (str): path to .ini config file
 
         Returns:
-            ConfigParser object, parsed from .ini file at 'filepath'
+            ConfigParser object, parsed from the .ini file at `filepath`
         """
         config = configparser.ConfigParser()
         config.read(filepath)
@@ -48,23 +48,20 @@ class Config(object):
         return config
 
     def _process_args(self, cli_args):
-        """Collect arguments from ini file if specificed.
+        """Collect arguments from .ini file if specificed.
 
-        Loads parameters from configparser at 'self.config'. Any identically
-        named arguments provided at the command line (provided as a dictionary
-        in 'cli_args') will overwrite those found in the configparser object.
-        Uses this final set of arguments to initialize and assign identically
-        named instance variables.
+        Loads parameters from ConfigParser object at 'self.config'. Any identically named arguments
+        provided at the command line (provided to this method as a dictionary in `cli_args`) will
+        overwrite those found in the ConfigParser object. Uses this final set of arguments to
+        initialize and assign identically named instance attributes.
 
         Args:
-            cli_args (dict): contains any arguments specified at the
-                command line (keys) and their values (values).
+            cli_args (dict): dictionary containing any arguments supplied at the command line.
 
         Returns:
             a dictionary containing the final harmonized and post processed arguments.
         """
         args = {}
-
         try:
             # parse config
             # mode
@@ -104,18 +101,18 @@ class Config(object):
             # TEMP
             args['variational_dropout'] = self.config['advanced'].getboolean('variational_dropout')
 
-        # Configparser throws a KeyError when you try to key into a configparser object that does
-        # not exist, catch it here, provide hint to the user
+        # ConfigParser throws a KeyError when you try to key into object that does not exist
+        # catch it here, provide hint to the user
         except KeyError as key:
             err_msg = ('KeyError raised for key {}. This may have happened because there is no '
                        '.ini file at: {}').format(key, self.filepath)
             self.log.error('KeyError %s', err_msg)
             print(err_msg)
         else:
-            # overwrite any parameters in the config if specfied at CL
+            # overwrite any parameters in the config if specfied at command line
             for key, value in cli_args.items():
-                # is not False is needed to prevent the store_true args from overriding the
-                # corresponding config file args when the are not passed at the CL.
+                # is not False needed to prevent store_true args from overriding  corresponding
+                # config file args when they are not passed at the command line.
                 if value is not None and value is not False:
                     args[key] = value
 
@@ -133,8 +130,8 @@ class Config(object):
     def _post_process_args(self, args):
         """Post process parameters retrived from python config file.
 
-        Performs series of post processing steps on 'parameters'. E.g., file and
-        directory path arguments are normalized, str arguments are cleaned.
+        Performs series of post processing steps on 'parameters'. E.g., file and directory path
+        arguments are normalized, string arguments are cleaned.
 
         Args:
             args (dict): contains arguments (keys) and their values (values).
@@ -149,13 +146,13 @@ class Config(object):
         args['criteria'] = Preprocessor.sterilize(args['criteria'], lower=True)
 
         # create normalized absolutized versions of paths
-        args['dataset_folder'] = [os.path.abspath(Preprocessor.sterilize(ds))
-                                  for ds in args['dataset_folder']]
-        args['output_folder'] = os.path.abspath(args['output_folder'])
+        args['dataset_folder'] = [generic_utils.clean_path(ds) for ds in args['dataset_folder']]
+        args['output_folder'] = generic_utils.clean_path(args['output_folder'])
         if args['pretrained_model_weights']:
-            args['pretrained_model_weights'] = os.path.abspath(args['pretrained_model_weights'])
+            args['pretrained_model_weights'] = generic_utils.clean_path(
+                args['pretrained_model_weights'])
         if args['pretrained_embeddings']:
-            args['pretrained_embeddings'] = os.path.abspath(args['pretrained_embeddings'])
+            args['pretrained_embeddings'] = generic_utils.clean_path(args['pretrained_embeddings'])
 
         # build dictionary for dropout rates
         args['dropout_rate'] = {
@@ -248,36 +245,35 @@ class Config(object):
 
         return vars(cli_args)
 
-    def save(self, filepath):
+    def save(self, dir_path):
         """Saves the harmonzied args sourced from the .ini file and the command line to filepath.
 
-        Saves a config.ini file at filepath, containing the harmonized arguments (`self.args`)
-        sourced from the original config file at `self.config` and any arguments supplied at the
-        command line. Returns True if the config.ini file was successfully created.
-
+        Saves a config.ini file at filepath, containing the harmonized arguments sourced from the
+        original config file at `self.config` and any arguments supplied at the command line.
+    
         Args:
-            filepath (str): filepath to save the config.ini file.
-
-        Returns:
-            True if the config.ini was successfully written to disk.
+            dir_path (str): directory path to save the config.ini file.
         """
-        path_to_save_config = os.path.join(filepath, 'config.ini')
-        with open(path_to_save_config, 'w') as config_file:
+        # get filepath to save config
+        dir_path = generic_utils.clean_path(dir_path)
+        generic_utils.make_dir(dir_path)
+        filepath = os.path.join(dir_path, 'config.ini')
+
+        with open(filepath, 'w') as config_file:
             for section in self.config.sections():
                 # write config file section header
                 config_file.write('[{}]\n'.format(section))
                 # for each argument in the section, write the argument and its value to the file
                 for arg in self.config[section]:
+                    value = getattr(self, arg)
                     # need to un-process processed arguments
-                    if isinstance(self.args[arg], list):
-                        harmonized_arg = ', '.join(self.args[arg])
-                    elif isinstance(self.args[arg], dict):
-                        values = [str(v) for v in self.args[arg].values()]
-                        harmonized_arg = ', '.join(values)
+                    if isinstance(value, list):
+                        unprocessed_value = ', '.join(value)
+                    elif isinstance(value, dict):
+                        unprocessed_value = [str(v) for v in value.values()]
+                        unprocessed_value = ', '.join(unprocessed_value)
                     else:
-                        harmonized_arg = self.args[arg]
+                        unprocessed_value = value
 
-                    config_file.write('{} = {}\n'.format(arg, harmonized_arg))
+                    config_file.write('{} = {}\n'.format(arg, unprocessed_value))
                 config_file.write('\n')
-
-        return True

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -61,3 +61,12 @@ MODELS = ['mt-lstm-crf',]
 # endpoint for Entrez Utilities Web Service API
 EUTILS_API_ENDPOINT = ('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?retmode=xml&db='
                        'pubmed&id=')
+
+# CONFIG
+
+CONFIG_ARGS = ['model_name', 'train_model', 'dataset_folder', 'output_folder',
+               'pretrained_model_weights', 'pretrained_embeddings', 'word_embed_dim',
+               'char_embed_dim', 'optimizer', 'activation', 'learning_rate', 'decay', 'grad_norm',
+               'dropout_rate', 'batch_size', 'k_folds', 'epochs', 'criteria', 'verbose',
+               'debug', 'tensorboard', 'replace_rare_tokens', 'fine_tune_word_embeddings',
+               'variational_dropout']

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -38,6 +38,9 @@ VALID_FILE = 'valid.*'
 TEST_FILE = 'test.*'
 # relative path to pretrained model directory
 PRETRAINED_MODEL_DIR = 'pretrained_models'
+MODEL_FILEPATH = 'model_params.json'
+WEIGHTS_FILEPATH = 'model_weights.hdf5'
+ATTRIBUTES_FILEPATH = 'attributes.pickle'
 
 # MODEL SETTINGS
 # batch size to use when performing model prediction

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -25,8 +25,7 @@ PAD_VALUE = 0 # value of sequence pad
 NUM_RARE = 1 # tokens that occur less than NUM_RARE times are replaced UNK
 
 # mapping of special tokens to contants
-INITIAL_MAPPING_WORDS = {PAD: 0, UNK: 1}
-INITIAL_MAPPING_TAGS = {PAD: 0}
+INITIAL_MAPPING = {'word': {PAD: 0, UNK: 1}, 'tag':  {PAD: 0}}
 
 # keys into dictionaries containing information for different partitions of a
 # dataset

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -49,6 +49,13 @@ PRED_BATCH_SIZE = 256
 MAX_SENT_LEN = 100
 # max length of a character sequence (word)
 MAX_CHAR_LEN = 25
+# number of units in the LSTM layers
+UNITS_WORD_LSTM = 200
+UNITS_CHAR_LSTM = 200
+UNITS_DENSE = UNITS_WORD_LSTM // 2
+
+# possible models
+MODELS = ['mt-lstm-crf',]
 
 # RESTful API
 # endpoint for Entrez Utilities Web Service API

--- a/saber/dataset.py
+++ b/saber/dataset.py
@@ -1,15 +1,13 @@
 """Contains the Dataset class, which handles the loading and storage of datasets.
 """
 from glob import glob
-import itertools
+from itertools import chain
 import logging
-import os.path
-
-import numpy as np
-from keras.utils import to_categorical
+import os
 
 from . import constants
 from .preprocessor import Preprocessor
+from .utils import model_utils
 
 class Dataset(object):
     """A class for handling datasets.
@@ -17,36 +15,29 @@ class Dataset(object):
     Args:
         filepath (str): path to directory containing a CoNLL formatted dataset
         sep (str): Seperator used for dataset at 'filepath'. Defaults to '\t'.
-        replace_rare_tokens (bool): True if rare tokens should be replaced
-        with a special unknown token. Threshold for considering tokens rare
-        can be found at constants.NUM_RARE.
+        replace_rare_tokens (bool): True if rare tokens should be replaced with a special unknown
+            token. Threshold for considering tokens rare can be found at constants.NUM_RARE.
     """
     def __init__(self, filepath, sep='\t', replace_rare_tokens=True):
         self.log = logging.getLogger(__name__)
         # collect filepaths for each partition in a dictionary
         self.partition_filepaths = self.get_filepaths(filepath)
-
         # column delimiter in CONLL dataset
         self.sep = sep
-        # replace all rare tokens with special unknown token
         self.replace_rare_tokens = replace_rare_tokens
 
-        # word and tag sequences from dataset, a dictionary of dictionaries
-        # containing partition: type key value pairs.
+        # word and tag seq from dataset, a dict of dict containing partition: type key value pairs.
         self.type_seq = {'train': {'word': None, 'char': None, 'tag': None},
                          'valid': {'word': None, 'char': None, 'tag': None},
                          'test': {'word': None, 'char': None, 'tag': None},}
 
-        # Word, character, and tag types from dataset
+        # word, character, and tag types from dataset
         self.types = {'word': None, 'char': None, 'tag': None}
-
         # mappings of type: index for word, character and tag types
         self.type_to_idx = {'word': None, 'char': None, 'tag': None}
         # inverse mapping from indices to tag types
         self.idx_to_tag = None
-
-        # identical to type_seq, except all types have been mapped to an integer
-        # index according to self.type_to_idx
+        # same as type_seq, but all types mapped to int idx according to self.type_to_idx
         self.idx_seq = {'train': {'word': None, 'char': None, 'tag': None},
                         'valid': {'word': None, 'char': None, 'tag': None},
                         'test': {'word': None, 'char': None, 'tag': None},}
@@ -92,73 +83,42 @@ class Dataset(object):
     def load_dataset(self, type_to_idx=None):
         """Coordinates loading of given data set at self.filepath.
 
-        For a given dataset in CoNLL format at filepath, cordinates
-        the loading of data and updates instance attributes. Expects
-        self.filepath to be a directory containing
-        a single file, train.* and optionally two additional files, valid.* and
-        test.*. If this is a type_to_idx must be provided.
+        For a given dataset in CoNLL format at filepath, cordinates the loading of data and updates
+        instance attributes. Expects self.filepath to be a directory containing a single file,
+        train.* and optionally two additional files, valid.* and test.*. If this is a type_to_idx
+        must be provided.
 
         Args:
             type_to_idx (dict): optional, a mapping of word types to indices
                 (at type_to_idx['word']) and a mapping of char types to indices
                 (at type_to_idx['char']) shared between datasets.
         """
-        # if type_to_idx is passed into function call, then this is a
-        # compound dataset (word and char index mappings shared across datasets)
+        # if not None, this is a compound dataset (word/char indx mappings shared across datasets)
         if type_to_idx is not None:
             self.type_to_idx.update(type_to_idx)
         else:
-            # load data and labels from file
             self.load_data_and_labels()
-            # get word, char, and tag types
             self.get_types()
             # generate type to index mappings
-            self.type_to_idx['word'] = Preprocessor.type_to_idx(
-                types=self.types['word'],
-                initial_mapping=constants.INITIAL_MAPPING_WORDS)
-            self.type_to_idx['char'] = Preprocessor.type_to_idx(
-                types=self.types['char'],
-                initial_mapping=constants.INITIAL_MAPPING_WORDS)
+            self.type_to_idx['word'] = Preprocessor.type_to_idx(self.types['word'],
+                                                                constants.INITIAL_MAPPING['word'])
+            self.type_to_idx['char'] = Preprocessor.type_to_idx(self.types['char'],
+                                                                constants.INITIAL_MAPPING['word'])
 
         # generate un-shared type to index mappings
-        self.type_to_idx['tag'] = Preprocessor.type_to_idx(
-            types=self.types['tag'],
-            initial_mapping=constants.INITIAL_MAPPING_TAGS
-        )
+        self.type_to_idx['tag'] = Preprocessor.type_to_idx(self.types['tag'],
+                                                           constants.INITIAL_MAPPING['tag'])
         # create reverse mapping of indices to tags, save computation downstream
         self.idx_to_tag = {v: k for k, v in self.type_to_idx['tag'].items()}
-
-        # get idx sequences
-        for partition in self.partition_filepaths:
-            self.idx_seq[partition] = {
-                'word': Preprocessor.get_type_idx_sequence(
-                    seq=self.type_seq[partition]['word'],
-                    type_to_idx=self.type_to_idx['word'],
-                    type_='word'),
-                'char': Preprocessor.get_type_idx_sequence(
-                    seq=self.type_seq[partition]['word'],
-                    type_to_idx=self.type_to_idx['char'],
-                    type_='char'),
-                'tag': Preprocessor.get_type_idx_sequence(
-                    seq=self.type_seq[partition]['tag'],
-                    type_to_idx=self.type_to_idx['tag'],
-                    type_='tag')
-            }
-
-            # convert tag idx sequences to categorical
-            self.idx_seq[partition]['tag'] = \
-                self._idx_seq_to_categorical(idx_seq=self.idx_seq[partition]['tag'],
-                                             num_classes=len(self.type_to_idx['tag']))
-        return self
+        self.get_idx_seq()
 
     def load_data_and_labels(self):
         """Loads CoNLL format data set given at self.trainset_filepath.
 
-        Updates self.word_seq and self.tag_seq each with a numpy array of lists
-        containg the word and tag sequence respectively. Expects filepath to be
-        a directory containing one file, train.*. The file format is
-        tab-separated values. A blank line is required at the end of each
-        sentence.
+        Updates self.word_seq and self.tag_seq each with a numpy array of lists containg the word
+        and tag sequence respectively. Expects filepath to be a directory containing one file,
+        train.*. The file format is tab-separated values. A blank line is required at the end of
+        each sentence.
 
         Example dataset:
         '''
@@ -168,10 +128,7 @@ class Dataset(object):
         most	O
         RP	B-PRGE
         genes	I-PRGE
-        is	O
-        activated	O
-        by	O
-        ...
+        ...	O
         '''
         """
         for partition, filepath in self.partition_filepaths.items():
@@ -192,7 +149,6 @@ class Dataset(object):
                             tag_seq.append(tags)
 
                             words, tags = [], []
-
                     # accumulate each word/tag in a sequence
                     else:
                         # ignore comment lines
@@ -209,8 +165,7 @@ class Dataset(object):
             if self.replace_rare_tokens:
                 word_seq = Preprocessor.replace_rare_tokens(word_seq)
 
-            self.type_seq[partition] = {'word': word_seq,
-                                        'tag': tag_seq}
+            self.type_seq[partition] = {'word': word_seq, 'tag': tag_seq}
 
     def get_types(self):
         """Returns word types, char types and tag types.
@@ -225,12 +180,11 @@ class Dataset(object):
             tag types.
         """
         # Word types
-        # iterate over all partitions which have a none-None value at
-        # type_seq[partition]['word'], that is, all partitions present in the
-        # dataset
+        # iterate over all partitions which have a not None value at type_seq[partition]['word'],
+        # that is, all partitions present in the dataset
         word_types = [s for p in self.type_seq.values() if p['word'] is not None for s in p['word']]
         # flatten list of word types, and convert to set to get unqiue elements
-        word_types = list(set(list(itertools.chain.from_iterable(word_types))))
+        word_types = list(set(chain.from_iterable(word_types)))
 
         # Char types
         char_types = []
@@ -240,29 +194,37 @@ class Dataset(object):
 
         # Tag types
         tag_types = [s for p in self.type_seq.values() if p['tag'] is not None for s in p['tag']]
-        tag_types = list(set(list(itertools.chain.from_iterable(tag_types))))
+        tag_types = list(set(chain.from_iterable(tag_types)))
 
         self.types['word'] = word_types
         self.types['char'] = char_types
         self.types['tag'] = tag_types
 
-    def _idx_seq_to_categorical(self, idx_seq, num_classes=None):
-        """One-hot encodes a given class vector.
+    def get_idx_seq(self):
+        """Get the index sequence for 'word', 'char', and 'tag' types for all paritions.
 
-        Converts a class vector of integers 'idx_seq' of shape
-        (num examples, sequence length) to a one-hot encoded matrix of shape
-        (num_examples, sequence length, num_classes).
-
-        Args:
-            idx_seq: class matrix of integers of shape (num examples,
-                sequence length), representing a sequence of tags
+        For paritions 'train' and (optionally) 'valid' and 'test', maps all 'word', 'char', and
+        'tag' types to a unique integer index. Returns a dictionary of dictionaries, where the
+        first dictionary contains keys for each parition ('train', 'valid', 'test') and the
+        nested dictionaries contains keys for each type ('word', 'char', 'tag').
 
         Returns:
-            numpy array, one-hot encoded matrix representation of 'idx_seq'
-            of shape (num examples, sequence length, num_classes)
+            dictionary of dictionaries, containing the index sequences for 'word', 'char', and 'tag'
+            types for all paritions 'train', 'valid' and 'test'.
         """
-        # convert to one-hot encoding
-        one_hots = [to_categorical(s, num_classes) for s in idx_seq]
-        one_hots = np.array(one_hots)
+        for partition in self.partition_filepaths:
+            self.idx_seq[partition] = {
+                'word': Preprocessor.get_type_idx_sequence(self.type_seq[partition]['word'],
+                                                           self.type_to_idx['word'],
+                                                           type_='word'),
+                'char': Preprocessor.get_type_idx_sequence(self.type_seq[partition]['word'],
+                                                           self.type_to_idx['char'],
+                                                           type_='char'),
+                'tag': Preprocessor.get_type_idx_sequence(self.type_seq[partition]['tag'],
+                                                          self.type_to_idx['tag'],
+                                                          type_='tag'),
+            }
 
-        return one_hots
+            self.idx_seq[partition]['tag'] = model_utils.idx_seq_to_categorical(
+                self.idx_seq[partition]['tag'], num_classes=len(self.type_to_idx['tag'])
+            )

--- a/saber/dataset.py
+++ b/saber/dataset.py
@@ -43,22 +43,22 @@ class Dataset(object):
                         'test': {'word': None, 'char': None, 'tag': None},}
 
     def get_filepaths(self, filepath):
-        """Collects train set, and valid/test set filepaths, if they exists.
+        """Collects 'train' (and, if they exist) 'valid'/'test' parition filepaths from `filepath`.
 
-        Looks for train, valid and test partitions at filepath/train.*, filepath/valid.* and
-        filepath/test.* respectively. Train set must be provided, valid and test sets are optional.
+        Looks for 'train', 'valid' and 'test' partitions at 'filepath/train.*', 'filepath/valid.*'
+        and 'filepath/test.*' respectively. Train set must be provided, valid and test sets are
+        optional.
 
         Args:
             filepath (str): path to dataset (corpus)
 
         Returns:
-            a dictionary with keys 'train', 'valid', 'test' and corresponding values containing the
+            a dictionary with keys 'train', and optionally, 'valid' and 'test' containing the
             filepaths to the train, valid and test paritions of the dataset at 'filepath'.
 
         Raises:
             ValueError when no file at filepath/train.* is found.
         """
-        # acc for each partitions filepath
         partition_filepaths = {}
         # search for partition filepaths
         train_partition = glob(os.path.join(filepath, constants.TRAIN_FILE))

--- a/saber/models/multi_task_lstm_crf.py
+++ b/saber/models/multi_task_lstm_crf.py
@@ -20,7 +20,7 @@ from keras.layers import TimeDistributed
 from keras.utils import multi_gpu_model
 import tensorflow as tf
 
-from . import constants
+from .. import constants
 from ..utils import model_utils
 
 # TODO (johngiorgi): I should to stratify the K-folds...
@@ -150,7 +150,7 @@ class MultiTaskLSTMCRF(object):
             # character-level embedding
             char_ids = Input(shape=(None, None), dtype='int32', name='char_id_inputs')
             char_embeddings = char_embeddings(char_ids)
-            
+
             # character-level BiLSTM + dropout. Spatial dropout applies the same dropout mask to all
             # timesteps which is necessary to implement variational dropout
             # (https://arxiv.org/pdf/1512.05287.pdf)

--- a/saber/models/multi_task_lstm_crf.py
+++ b/saber/models/multi_task_lstm_crf.py
@@ -16,6 +16,7 @@ from keras.models import Input
 from keras.layers import Lambda
 from keras.layers import LSTM
 from keras.models import Model
+from keras.models import model_from_json
 from keras.layers import SpatialDropout1D
 from keras.layers import TimeDistributed
 from keras.utils import multi_gpu_model
@@ -63,6 +64,31 @@ class MultiTaskLSTMCRF(object):
         self.model = []
 
         self.log = logging.getLogger(__name__)
+
+    def save(self, weights_filepath, model_filepath, model=0):
+        """Save a model to disk.
+
+        Args:
+            weights_filepath (str): filepath to the models wieghts (.hdf5 file)
+            model_filepath (str): filepath to the models architecture (.json file)
+            model (int): which model from `self.model` to save
+        """
+        with open(model_filepath, 'w') as f:
+            model_json = self.model[model].to_json()
+            json.dump(json.loads(model_json), f, sort_keys=True, indent=4)
+            self.model[model].save_weights(weights_filepath)
+
+    def load(self, weights_filepath, model_filepath):
+        """Load a model from disk.
+
+        Args:
+            weights_filepath (str): filepath to the models wieghts (.hdf5 file)
+            model_filepath (str): filepath to the models architecture (.json file)
+        """
+        with open(model_filepath) as f:
+            model = model_from_json(f.read(), custom_objects={'CRF': CRF})
+            model.load_weights(weights_filepath)
+            self.model.append(model)
 
     def specify_(self):
         """Specifies a multi-task BiLSTM-CRF for sequence tagging using Keras.

--- a/saber/models/multi_task_lstm_crf.py
+++ b/saber/models/multi_task_lstm_crf.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 from keras import initializers
-import keras.backend as K
 from keras_contrib.layers.crf import CRF
 from keras.layers import Bidirectional
 from keras.layers import Concatenate
@@ -13,7 +12,6 @@ from keras.layers import Dense
 from keras.layers import Dropout
 from keras.layers import Embedding
 from keras.models import Input
-from keras.layers import Lambda
 from keras.layers import LSTM
 from keras.models import Model
 from keras.models import model_from_json

--- a/saber/preprocessor.py
+++ b/saber/preprocessor.py
@@ -103,7 +103,7 @@ class Preprocessor(object):
     def type_to_idx(types, initial_mapping=None, offset=0):
         """Returns a dictionary of element:index pairs for each element in types.
 
-        Given a list `types`, returns a dictionary of length len(types) + offset where the keys are
+        Given a list `types`, returns a dictionary of length len(types) + offset, where the keys are
         elements of `types` and the values are unique integer ids.
 
         Args:

--- a/saber/sequence_processor.py
+++ b/saber/sequence_processor.py
@@ -143,7 +143,7 @@ class SequenceProcessor(object):
                             'idx_to_tag': self.ds[model_idx].idx_to_tag,
                            }
         # save weights, model architecture, dataset it was trained on, and configuration file
-        self.model.save(weights_filepath, model_filepath, model)
+        self.model.save(weights_filepath, model_filepath, model_idx)
         pickle.dump(model_attributes, open(attributes_filepath, 'wb'))
         self.config.save(directory)
 

--- a/saber/sequence_processor.py
+++ b/saber/sequence_processor.py
@@ -197,7 +197,7 @@ class SequenceProcessor(object):
 
         if directory is not None:
             directory = directory if isinstance(directory, list) else [directory]
-            directory = [generic_utils.clean_path(d) for d in directory]
+            directory = [generic_utils.clean_path(dir) for dir in directory]
             self.config.dataset_folder = directory
 
         if not self.config.dataset_folder:

--- a/saber/sequence_processor.py
+++ b/saber/sequence_processor.py
@@ -280,7 +280,7 @@ class SequenceProcessor(object):
             A list containing multiple compound dataset objects.
         """
         # accumulate datasets
-        compound_ds = [Dataset(ds, self.config.replace_rare_tokens) for ds in
+        compound_ds = [Dataset(ds, replace_rare_tokens=self.config.replace_rare_tokens) for ds in
                        self.config.dataset_folder]
 
         for ds in compound_ds:

--- a/saber/sequence_processor.py
+++ b/saber/sequence_processor.py
@@ -46,7 +46,7 @@ class SequenceProcessor(object):
 
         if self.config.verbose:
             print('Hyperparameters and model details:')
-            pprint(self.config.args)
+            pprint({arg: getattr(self.config, arg) for arg in constants.CONFIG_ARGS})
             os.environ['TF_CPP_MIN_LOG_LEVEL'] = '0'
 
     def annotate(self, text, model_idx=0, jupyter=False):

--- a/saber/sequence_processor.py
+++ b/saber/sequence_processor.py
@@ -207,9 +207,13 @@ class SequenceProcessor(object):
         self.model.load(weights_filepath, model_filepath)
         self.model.compile_()
 
-    def load_dataset(self):
+    def load_dataset(self, filepath=None):
         """Coordinates the loading of a dataset."""
         start = time.time()
+
+        if filepath is not None:
+            self.config.dataset_folder = filepath
+
         if not self.config.dataset_folder:
             err_msg = "Must provide at least one dataset via the 'dataset_folder' parameter"
             self.log.error('AssertionError %s', err_msg)
@@ -217,8 +221,7 @@ class SequenceProcessor(object):
 
         # if not None, then pre-trained model has been loaded, use its type mapping
         type_to_idx = None if not self.ds else self.ds[0].type_to_idx
-        # Datasets may be 'single' or 'compound' (more than one). Consider a dataset single if
-        # there is only one filepath in self.config.dataset_folder' and compound otherwise.
+        # datasets may be 'single' or 'compound' (more than one)
         if len(self.config.dataset_folder) == 1:
             print('Loading (single) dataset... ', end='', flush=True)
             self.ds = self._load_single_dataset(type_to_idx)
@@ -357,7 +360,7 @@ class SequenceProcessor(object):
                 ds_name = os.path.basename(self.config.dataset_folder[i])
                 print('Model architecture for dataset {}:'.format(ds_name))
                 model.summary()
-r
+
     def fit(self):
         """Fit the specified model.
 

--- a/saber/tests/test_config.py
+++ b/saber/tests/test_config.py
@@ -125,15 +125,14 @@ def config_with_cli_args():
     config = Config(filepath=PATH_TO_DUMMY_CONFIG, cli=False)
     # this is a bit of a hack, but need to simulate providing commands at the command line
     config.cli_args = DUMMY_COMMAND_LINE_ARGS
-    config.args = config._process_args(DUMMY_COMMAND_LINE_ARGS)
+    config._process_args(DUMMY_COMMAND_LINE_ARGS)
     return config
 
 def test_process_args_no_cli_args(config_no_cli_args):
     """Asserts the Config.config object contains the expected attributes after initializing a Config
     object without CLI args."""
     # check filepath attribute
-    assert config_no_cli_args.filepath == os.path.join(os.path.dirname( \
-        os.path.os.path.abspath(__file__)), PATH_TO_DUMMY_CONFIG)
+    assert config_no_cli_args.filepath == os.path.join(os.path.dirname(os.path.os.path.abspath(__file__)), PATH_TO_DUMMY_CONFIG)
     # check that the config file contains the same values as DUMMY_ARGS_NO_PROCESSING
     config = config_no_cli_args.config
     for section in CONFIG_SECTIONS:
@@ -141,9 +140,6 @@ def test_process_args_no_cli_args(config_no_cli_args):
             assert value == DUMMY_ARGS_NO_PROCESSING[arg]
     # check cli_args attribute
     assert config_no_cli_args.cli_args == {}
-    # check args attribute
-    for arg, value in config_no_cli_args.args.items():
-        assert value == DUMMY_ARGS_NO_CLI_ARGS[arg]
 
 def test_process_args_with_cli_args(config_with_cli_args):
     """Asserts the Config.config object contains the expected attributes after initializing a Config
@@ -158,9 +154,6 @@ def test_process_args_with_cli_args(config_with_cli_args):
             assert value == DUMMY_ARGS_NO_PROCESSING[arg]
     # check cli_args attribute
     assert config_with_cli_args.cli_args == DUMMY_COMMAND_LINE_ARGS
-    # check args attribute
-    for arg, value in config_with_cli_args.args.items():
-        assert value == DUMMY_ARGS_WITH_CLI_ARGS[arg]
 
 def test_config_attributes_no_cli_args(config_no_cli_args):
     """Asserts that the class attributes of a Config object are of the expected value/type after
@@ -186,10 +179,8 @@ def test_save_no_cli_args(config_no_cli_args, tmpdir):
     config_no_cli_args.save(tmpdir)
     # load the saved config
     saved_config = load_saved_config(tmpdir)
-
     # need to 'unprocess' the args to check them against the saved config file
     unprocessed_args = unprocess_args(DUMMY_ARGS_NO_CLI_ARGS)
-
     # ensure the saved config file matches the original arguments used to create it
     for section in CONFIG_SECTIONS:
         for arg, value in saved_config[section].items():
@@ -203,10 +194,8 @@ def test_save_with_cli_args(config_with_cli_args, tmpdir):
     config_with_cli_args.save(tmpdir)
     # load the saved config
     saved_config = load_saved_config(tmpdir)
-
     # need to 'unprocess' the args to check them against the saved config file
     unprocessed_args = unprocess_args(DUMMY_ARGS_WITH_CLI_ARGS)
-
     # ensure the saved config file matches the original arguments used to create it
     for section in CONFIG_SECTIONS:
         for arg, value in saved_config[section].items():

--- a/saber/utils/generic_utils.py
+++ b/saber/utils/generic_utils.py
@@ -24,6 +24,17 @@ def make_dir(directory_filepath):
         if err.errno != errno.EEXIST:
             raise
 
+def clean_path(path):
+    """Returns normalized and absolutized `path`.
+
+    Args:
+        path (str): path to be normalized and absolutized
+
+    Returns:
+        `path`, normalized and absolutized
+    """
+    return os.path.abspath(os.path.normpath(path))
+
 def decompress_model(filepath):
     """Decompresses a bz2 compressed Saber model.
 
@@ -36,7 +47,7 @@ def decompress_model(filepath):
     if not os.path.isdir(filepath):
         head, _ = os.path.split(os.path.abspath(filepath))
 
-        print('[INFO] Unzipping pretrained model... '.format(), end='', flush=True)
+        print('Unzipping pretrained model... '.format(), end='', flush=True)
         unpack_archive(filepath + '.tar.bz2', extract_dir=head)
         print('Done.')
 

--- a/saber/utils/model_utils.py
+++ b/saber/utils/model_utils.py
@@ -6,6 +6,8 @@ from time import strftime
 from keras import optimizers
 from keras.callbacks import ModelCheckpoint
 from keras.callbacks import TensorBoard
+from keras.utils import to_categorical
+import numpy as np
 from sklearn.model_selection import KFold
 
 from ..metrics import Metrics
@@ -237,8 +239,7 @@ def get_data_partitions(training_data, train_valid_indices, fold):
     """
     # TODO: this seems like a sub-par solution
     # acc, p = partition, s = split
-    partitioned_data = {p: {s: None for s in training_data[p]} for p in
-        training_data}
+    partitioned_data = {p: {s: None for s in training_data[p]} for p in training_data}
 
     for i in training_data:
         # train_valid_indices[i][fold] is a two-tuple, where index 0 contains
@@ -286,3 +287,23 @@ def get_metrics(datasets, training_data, output_dir, criteria='exact', fold=None
         metrics.append(metrics_)
 
     return metrics
+
+def idx_seq_to_categorical(idx_seq, num_classes=None):
+    """One-hot encodes a given class vector.
+
+    Converts a class matrix of integers, `idx_seq`, of shape (num examples, sequence length) to a
+    one-hot encoded matrix of shape (num_examples, sequence length, num_classes).
+
+    Args:
+        idx_seq: class matrix of integers of shape (num examples, sequence length), representing a
+            sequence of tags
+
+    Returns:
+        numpy array, one-hot encoded matrix representation of `idx_seq` of shape
+            (num examples, sequence length, num_classes)
+    """
+    # convert to one-hot encoding
+    one_hots = [to_categorical(s, num_classes) for s in idx_seq]
+    one_hots = np.array(one_hots)
+
+    return one_hots


### PR DESCRIPTION
With this pull request you can now perform transfer learning as follows:

```python
from saber.sequence_processor import SequenceProcessor

sp = SequenceProcessor()

# assuming this model exists
sp.load('path/to/pretrained_models/PRGE')

# load a dataset
sp.load_dataset('datasets/CRAFT')

# train
sp.fit()
```

This is the simplest implementation I could think up.

**TODOS**

- [x] ~~`sp.load_embeddings()` should not load the embeddings if `sp.token_embedding_matrix` is not `None`, otherwise the embeddings used during training on the source will be overwritten and the transfer will be pointless.~~ No longer a problem, loading embeddings after loading a model will have no effect, just wastes time!
- [x] ~~Include some way to exclude loading weights from certain layers. Should be easy to implement, probably in the `load_weights()` call in `SequenceProcessor.load()`. Harder question is how to let user choose what to load.~~ Move this to its own pull request. Pretty low priority for now.
- [x] As a sainity check, perform a transfer learning setup and compare to results from our transfer learning study. Should get the same performance bump if this is done properly!
- [x] I need to carry over the mapping from `type_to_idx['tag']` during a transfer

**Changed**

**Resources**

- [This](https://machinelearningmastery.com/save-load-keras-deep-learning-models/) blog on saving and loading keras models

Closes #29 & closes #30.