### PR TITLE
Add coreference

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Finally, you must also `pip` install the required [Spacy](https://spacy.io) mode
 ```bash
 # keras-contrib
 (saber) $ pip install git+https://www.github.com/keras-team/keras-contrib.git
-# spacy small english model
-(saber) $ pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz#en_core_web_sm
+# NeuralCoref Large model built on top of Spacy, this might take a while to download!
+(saber) $ pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz
 ```
 
 ### (OPTIONAL) Creating and activating virtual environments

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Finally, you must also `pip` install the required [Spacy](https://spacy.io) mode
 ```bash
 # keras-contrib
 (saber) $ pip install git+https://www.github.com/keras-team/keras-contrib.git
-# NeuralCoref Large model built on top of Spacy, this might take a while to download!
-(saber) $ pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz
+# NeuralCoref medium model built on top of Spacy, this might take a few minutes to download!
+(saber) $ pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_md-3.0.0/en_coref_md-3.0.0.tar.gz
 ```
 
 ### (OPTIONAL) Creating and activating virtual environments

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,4 +4,12 @@ __Saber__ (__S__equence __A__nnotator for __B__iomedical __E__ntities and __R__e
 
 The neural network model used is a BiLSTM-CRF [[1](https://arxiv.org/abs/1603.01360), [2](https://arxiv.org/abs/1603.01354)]; a state-of-the-art architecture for sequence labelling. The model is implemented using [Keras](https://keras.io/).
 
+The goal is that Saber will eventually perform all the important steps in text-mining of biomedical literature:
+
+- Biomedical named entity recognition (BioNER) (:white_check_mark:)
+- Coreference resolution (:white_check_mark:)
+- Entity linking / grounding / normalization (:soon:)
+- Simple relation extraction (:soon:)
+- Event extraction (:soon:)
+
 Pull requests are welcome! If you encounter any bugs, please open an issue in the [GitHub repository](https://github.com/BaderLab/saber).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ The neural network model used is a BiLSTM-CRF [[1](https://arxiv.org/abs/1603.01
 
 The goal is that Saber will eventually perform all the important steps in text-mining of biomedical literature:
 
-- Biomedical named entity recognition (BioNER) (:white_check_mark:)
 - Coreference resolution (:white_check_mark:)
+- Biomedical named entity recognition (BioNER) (:white_check_mark:)
 - Entity linking / grounding / normalization (:soon:)
 - Simple relation extraction (:soon:)
 - Event extraction (:soon:)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,12 +36,11 @@ Finally, you must also `pip` install the required [Spacy](https://spacy.io) mode
 ```
 # keras-contrib
 (saber) $ pip install git+https://www.github.com/keras-team/keras-contrib.git
-# NeuralCoref Large model built on top of Spacy, this might take a while to download!
-(saber) $ pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz
+# NeuralCoref medium model built on top of Spacy, this might take a few minutes to download!
+(saber) $ pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_md-3.0.0/en_coref_md-3.0.0.tar.gz
 ```
 
 > See [Running tests](#running-tests) for a way to verify your installation.
-
 
 ### (OPTIONAL) Creating and activating virtual environments
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,8 +36,8 @@ Finally, you must also `pip` install the required [Spacy](https://spacy.io) mode
 ```
 # keras-contrib
 (saber) $ pip install git+https://www.github.com/keras-team/keras-contrib.git
-# spacy small english model
-(saber) $ pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz#en_core_web_sm
+# NeuralCoref Large model built on top of Spacy, this might take a while to download!
+(saber) $ pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz
 ```
 
 > See [Running tests](#running-tests) for a way to verify your installation.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -77,6 +77,26 @@ To annotate text with the model, just call the `annotate()` method
 sp.annotate('A Sos-1-E3b1 complex directs Rac activation by entering into a tricomplex with Eps8.')
 ```
 
+### Coreference Resolution
+
+[**Coreference**](http://www.wikiwand.com/en/Coreference) occurs when two or more expressions in a text refer to the same person or thing, that is, they have the same **referent**. Take the following example:
+
+_"IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy."_
+
+Clearly, _"it"_ referes to _"IL-6"_. If we do not resolve this coreference, then _"it"_ will not be labeled as an entity and any relation or event it is mentioned in will not be extracted. Saber uses [NeuralCoref](https://github.com/huggingface/neuralcoref), a state-of-the-art coreference resolution tool based on neural nets and built on top of [Spacy](https://spacy.io). To use it, just supply the argument `coref=True` (which is `False` by default) to the `annotate()` method
+
+```python
+text = "IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy."
+# WITHOUT coreference resolution
+sp.annotate(text, coref=False)
+# WITH coreference resolution
+sp.annotate(text, coref=True)
+```
+
+> Note that if you are using the web-service, simply supply `"coref": true` in your `JSON` payload to resolve coreferences.
+
+Saber currently takes the simplest possible approach: replace all coreference mentions with their referent, and then feed the resolved text to the model that identifies named entities.
+
 ### Working with annotations
 
 The `annotate()` method returns a simple `dict` object

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ theme:
 
 markdown_extensions:
   - codehilite
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:pymdownx.emoji.to_svg
 
 repo_name: 'BaderLab/saber'
 repo_url: 'https://github.com/BaderLab/saber'

--- a/notebooks/lightning_tour.ipynb
+++ b/notebooks/lightning_tour.ipynb
@@ -220,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sp.annotate('A Sos-1-E3b1 complex directs Rac activation by entering into a tricomplex with Eps8.')"
+    "sp.annotate('The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.', jupyter=True)"
    ]
   },
   {

--- a/notebooks/lightning_tour.ipynb
+++ b/notebooks/lightning_tour.ipynb
@@ -220,7 +220,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sp.annotate('The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.', jupyter=True)"
+    "text = \"IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy.\"\n",
+    "# text = \"Interleukin-6 is a multifaceted cytokine, usually reported as a pro-inflammatory molecule. However, certain anti-inflammatory activities were also attributed to IL-6. The levels of IL-6 in serum as well as in other biological fluids are elevated in an age-dependent manner. Notably, it is consistently reported also as a key feature of the senescence-associated secretory phenotype. In the elderly, this cytokine participates in the initiation of catabolism resulting in, e.g. sarcopenia. It can cross the blood-brain barrier, and so it is in causal association with, e.g. depression, bipolar disorder, schizophrenia, and anorexia. In the cancer patient, IL-6 is produced by cancer and stromal cells and actively participates in their crosstalk. IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy. The pharmacological treatment impairing IL-6 signalling represents a potential mechanism of anti-tumour therapy targeting cancer growth, metastatic spread, metabolic deterioration and terminal cachexia in patients.\"\n",
+    "sp.annotate(text, coref=False, jupyter=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Coreference Resolution\n",
+    "\n",
+    "[**Coreference**](http://www.wikiwand.com/en/Coreference) occurs when two or more expressions in a text refer to the same person or thing, that is, they have the same **referent**. Take the following example:\n",
+    "\n",
+    "_\"IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy.\"_\n",
+    "\n",
+    "Clearly, _\"it\"_ referes to _\"IL-6\"_. If we do not resolve this coreference, then _\"it\"_ will not be labeled as an entity and any relation or event it is mentioned in will not be extracted. Saber uses [NeuralCoref](https://github.com/huggingface/neuralcoref), a state-of-the-art coreference resolution tool based on neural nets and built on top of [Spacy](https://spacy.io). To use it, just supply the argument `coref=True` (which is `False` by default) to the `annotate()` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = \"IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy.\"\n",
+    "# WITHOUT coreference resolution\n",
+    "sp.annotate(text, coref=False, jupyter=True)\n",
+    "# WITH coreference resolution\n",
+    "sp.annotate(text, coref=True, jupyter=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Note that if you are using the web-service, simply supply `\"coref\": true` in your `JSON` payload to resolve coreferences.\n",
+    "\n",
+    "Saber currently takes the simplest possible approach: replace all coreference mentions with their referent, and then feed the resolved text to the model that identifies named entities."
    ]
   },
   {
@@ -267,7 +304,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Converting annotations to JSON\n",
+    "##### Converting annotations to JSON\n",
     "\n",
     "The `annotate()` method returns a `dict` object, but can be converted to a `JSON` formatted string for ease-of-use in downstream applications"
    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ keras>=2.2.2
 PTable>=0.9.2
 gensim>=3.4.0
 spacy>=2.0.11
-# NeuralCoref large model
-https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz
+# NeuralCoref medium model
+https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_md-3.0.0/en_coref_md-3.0.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ keras>=2.2.2
 PTable>=0.9.2
 gensim>=3.4.0
 spacy>=2.0.11
-# Spacy small english language model
-https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.0.0/en_core_web_sm-2.0.0.tar.gz#en_core_web_sm
+# NeuralCoref large model
+pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ PTable>=0.9.2
 gensim>=3.4.0
 spacy>=2.0.11
 # NeuralCoref large model
-pip install https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz
+https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_lg-3.0.0/en_coref_lg-3.0.0.tar.gz

--- a/saber/preprocessor.py
+++ b/saber/preprocessor.py
@@ -97,9 +97,11 @@ class Preprocessor(object):
             for cluster in doc._.coref_clusters:
                 referent = cluster.main
                 for mention in cluster.mentions:
-                    first_token, last_token = doc[mention.start], doc[mention.end - 1]
-                    start, end = first_token.idx, last_token.idx + len(last_token.text)
-                    coreference.append((referent.text, start, end))
+                    # exclude the referent itself from being captured
+                    if mention.text != referent.text:
+                        first_token, last_token = doc[mention.start], doc[mention.end - 1]
+                        start, end = first_token.idx, last_token.idx + len(last_token.text)
+                        coreference.append((referent.text, start, end))
 
         # collect token sequence
         for sent in doc.sents:

--- a/saber/tests/test_preprocessor.py
+++ b/saber/tests/test_preprocessor.py
@@ -1,3 +1,4 @@
+import en_coref_md
 import pytest
 
 from .. import constants
@@ -6,20 +7,23 @@ from ..preprocessor import Preprocessor
 @pytest.fixture
 def preprocessor():
     """Returns an instance of a Preprocessor object."""
-    preprocessor = Preprocessor()
+    return Preprocessor()
 
-    return preprocessor
+@pytest.fixture
+def nlp():
+    """Returns Sacy NLP model."""
+    return en_coref_md.load()
 
-def test_process_text(preprocessor):
+def test_process_text(preprocessor, nlp):
     """Asserts that call to Preprocessor._process_text() returns the expected
     results."""
     # simple test and its expected value
-    simple_text = "Simple example. With two sentences!"
+    simple_text = nlp("Simple example. With two sentences!")
     simple_expected = ([['Simple', 'example', '.'], ['With', 'two', \
         'sentences', '!']], [[(0, 6), (7, 14), (14, 15)], [(16, 20),\
          (21, 24), (25, 34), (34, 35)]])
     # blank value test and its expected value
-    blank_test = ""
+    blank_test = nlp("")
     blank_expected = ([], [])
 
     assert preprocessor._process_text(simple_text) == simple_expected

--- a/saber/utils/generic_utils.py
+++ b/saber/utils/generic_utils.py
@@ -84,8 +84,6 @@ def compress_model(dir_path):
     shutil.make_archive(base_name=dir_path, format='bztar', root_dir=root_dir, base_dir=base_dir)
     shutil.rmtree(dir_path)
 
-    return True
-
 def get_pretrained_model_dir(config):
     """Returns path to top-level directory to save a pretrained model.
 
@@ -103,8 +101,3 @@ def get_pretrained_model_dir(config):
     """
     ds_names = '_'.join([os.path.basename(ds) for ds in config.dataset_folder])
     return os.path.join(config.output_folder, constants.PRETRAINED_MODEL_DIR, ds_names)
-
-def str_similarity(a, b):
-    """Returns a simple similarity score for two strings `a` and `b`.
-    """
-    return SequenceMatcher(None, a, b).ratio()

--- a/saber/utils/generic_utils.py
+++ b/saber/utils/generic_utils.py
@@ -4,7 +4,6 @@ import errno
 import logging
 import os
 import shutil
-from difflib import SequenceMatcher
 from setuptools.archive_util import unpack_archive
 
 from .. import constants

--- a/saber/utils/generic_utils.py
+++ b/saber/utils/generic_utils.py
@@ -4,6 +4,7 @@ import errno
 import logging
 import os
 import shutil
+from difflib import SequenceMatcher
 from setuptools.archive_util import unpack_archive
 
 from .. import constants
@@ -102,3 +103,8 @@ def get_pretrained_model_dir(config):
     """
     ds_names = '_'.join([os.path.basename(ds) for ds in config.dataset_folder])
     return os.path.join(config.output_folder, constants.PRETRAINED_MODEL_DIR, ds_names)
+
+def str_similarity(a, b):
+    """Returns a simple similarity score for two strings `a` and `b`.
+    """
+    return SequenceMatcher(None, a, b).ratio()


### PR DESCRIPTION
This pull request adds coreference resolution by using the Spacy model trained and provided by [NeuralCoref](https://github.com/huggingface/neuralcoref). This allows Saber to handle, for example, the following situation:

_"We identify the **scaffold p62/SQSTM1 protein** as a novel VANGL2-binding partner and show **its** key role in an evolutionarily conserved VANGL2–p62/SQSTM1–JNK pathway"_

by resolving "**its**" to "**scaffold p62/SQSTM1 protein**". This should improve performance in downstream tasks like relation extraction. 

Closes #43.