### PR TITLE
Fix issue that resulting in spacy install being skipped

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask>=1.0.2
 git+https://www.github.com/keras-team/keras-contrib.git
 keras>=2.2.2
 PTable>=0.9.2
-gensim>=3.4.0
 spacy>=2.0.11
+gensim>=3.4.0
 # NeuralCoref medium model
 https://github.com/huggingface/neuralcoref-models/releases/download/en_coref_md-3.0.0/en_coref_md-3.0.0.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setuptools.setup(
         'Flask>=1.0.2',
         'keras>=2.2.2',
         'PTable>=0.9.2',
-        'gensim>=3.4.0'
         'spacy>=2.0.11',
+        'gensim>=3.4.0'
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
The relative ordering of dependencies in `requirements.txt` and `setup.py` meant that spacy wasn't actually being installed. Fixed!