### PR TITLE
Adding better tokenization of biomedical entities

### DIFF
--- a/notebooks/lightning_tour.ipynb
+++ b/notebooks/lightning_tour.ipynb
@@ -220,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "text = \"IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy.\"\n",
+    "text = \"The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.\"\n",
     "# text = \"Interleukin-6 is a multifaceted cytokine, usually reported as a pro-inflammatory molecule. However, certain anti-inflammatory activities were also attributed to IL-6. The levels of IL-6 in serum as well as in other biological fluids are elevated in an age-dependent manner. Notably, it is consistently reported also as a key feature of the senescence-associated secretory phenotype. In the elderly, this cytokine participates in the initiation of catabolism resulting in, e.g. sarcopenia. It can cross the blood-brain barrier, and so it is in causal association with, e.g. depression, bipolar disorder, schizophrenia, and anorexia. In the cancer patient, IL-6 is produced by cancer and stromal cells and actively participates in their crosstalk. IL-6 supports tumour growth and metastasising in terminal patients, and it significantly engages in cancer cachexia (including anorexia) and depression associated with malignancy. The pharmacological treatment impairing IL-6 signalling represents a potential mechanism of anti-tumour therapy targeting cancer growth, metastatic spread, metabolic deterioration and terminal cachexia in patients.\"\n",
     "sp.annotate(text, coref=False, jupyter=True)"
    ]
@@ -275,7 +275,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ann = sp.annotate('A Sos-1-E3b1 complex directs Rac activation by entering into a tricomplex with Eps8.')"
+    "ann = sp.annotate(\"The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.\")"
    ]
   },
   {

--- a/saber/preprocessor.py
+++ b/saber/preprocessor.py
@@ -10,6 +10,7 @@ import numpy as np
 from keras.preprocessing.sequence import pad_sequences
 
 from . import constants
+from .utils import text_utils
 
 class Preprocessor(object):
     """A class for processing text data."""
@@ -19,6 +20,8 @@ class Preprocessor(object):
     def __init__(self):
         # load the NeuralCoref model, which is built on top of the Spacy english model
         self.nlp = en_coref_md.load()
+        # Load our modified tokenizer, better tokenization of biomedical text
+        self.nlp.tokenizer = text_utils.biomedical_tokenizer(self.nlp)
 
     def transform(self, text, word2idx, char2idx, coref=False, sterilize=True):
         """Returns a dictionary collected from processing `text`, including sentences, offsets,

--- a/saber/tests/test_text_utils.py
+++ b/saber/tests/test_text_utils.py
@@ -1,0 +1,63 @@
+import en_coref_md
+import pytest
+
+from ..utils import text_utils
+
+@pytest.fixture
+def nlp():
+    """Returns an instance of a spaCy's nlp object after replacing the default tokenizer with
+    our modified one."""
+    custom_nlp = en_coref_md.load()
+    custom_nlp.tokenizer = text_utils.biomedical_tokenizer(custom_nlp)
+    return custom_nlp
+
+def test_biomedical_tokenizer(nlp):
+    """Asserts that call to customized spaCy tokenizer returns the expected results.
+    """
+    # the empty string
+    blank_text = ""
+    blank_expected = []
+    # simple test with no complexities
+    simple_text = "This is an easy test."
+    simple_expected = ["This", "is", "an", "easy", "test", "."]
+    # complicated test with some important edge cases
+    complicated_test = ("This test's tokenizers handeling of very-tricky situations, 3X, "
+                        "more/or/less.")
+    complicated_expected = ["This", "test", "'", "s", "tokenizers", "handeling", "of",
+                            "very", "-", "tricky", "situations", ",", "3X", ",", "more", "/", "or",
+                            "/", "less", "."]
+
+    # these tests were taken straight from training data
+    from_CHED_ds = ("The results have shown that the degradation product p-choloroaniline is not "
+                    "a significant factor in chlorhexidine-digluconate associated erosive "
+                    "cystitis.")
+    from_CHED_ds_expected = ['The', 'results', 'have', 'shown', 'that', 'the', 'degradation',
+                             'product', 'p', '-', 'choloroaniline', 'is', 'not', 'a', 'significant',
+                             'factor', 'in', 'chlorhexidine', '-', 'digluconate', 'associated',
+                             'erosive', 'cystitis', '.']
+    from_DISO_ds = ("Rats were treated with seven day intravenous infusion of fucoidan "
+                    "(30 micrograms h-1) or vehicle.")
+    from_DISO_expected = ['Rats', 'were', 'treated', 'with', 'seven', 'day', 'intravenous',
+                          'infusion', 'of', 'fucoidan', '(', '30', 'micrograms', 'h', '-', '1',
+                          ')', 'or', 'vehicle', '.']
+    from_LIVB_ds = ("Methanoregula formicica sp. nov., a methane-producing archaeon isolated from "
+                    "methanogenic sludge.")
+    from_LIVB_ds_expected = ['Methanoregula', 'formicica', 'sp', '.', 'nov', '.', ',', 'a',
+                             'methane', '-', 'producing', 'archaeon', 'isolated', 'from',
+                             'methanogenic', 'sludge', '.']
+    from_PRGE_ds = ("Here we report the cloning, expression, and biochemical characterization of "
+                    "the 32-kDa subunit of human (h) TFIID, termed hTAFII32.")
+    from_PRGE_ds_expected = ['Here', 'we', 'report', 'the', 'cloning', ',', 'expression', ',',
+                            'and', 'biochemical', 'characterization', 'of', 'the', '32', '-', 'kDa',
+                            'subunit', 'of', 'human', '(', 'h', ')', 'TFIID', ',', 'termed',
+                            'hTAFII32', '.']
+
+    # generic tests
+    assert [t.text for t in nlp(blank_text)] == blank_expected
+    assert [t.text for t in nlp(simple_text)] == simple_expected
+    assert [t.text for t in nlp(complicated_test)] == complicated_expected
+    # tests taken straight from training data
+    assert [t.text for t in nlp(from_CHED_ds)] == from_CHED_ds_expected
+    assert [t.text for t in nlp(from_DISO_ds)] == from_DISO_expected
+    assert [t.text for t in nlp(from_LIVB_ds)] == from_LIVB_ds_expected
+    assert [t.text for t in nlp(from_PRGE_ds)] == from_PRGE_ds_expected

--- a/saber/utils/text_utils.py
+++ b/saber/utils/text_utils.py
@@ -9,5 +9,9 @@ from spacy.tokenizer import Tokenizer
 # https://github.com/spyysalo/standoff2conll/blob/master/common.py
 INFIX_RE = re.compile(r'''([0-9a-zA-Z]+|[^0-9a-zA-Z])''')
 
+# https://spacy.io/usage/linguistic-features#native-tokenizers
 def biomedical_tokenizer(nlp):
+    """
+    Customizes spaCy's tokenizer class for better handeling of biomedical text.
+    """
     return Tokenizer(nlp.vocab, infix_finditer=INFIX_RE.finditer)

--- a/saber/utils/text_utils.py
+++ b/saber/utils/text_utils.py
@@ -1,0 +1,13 @@
+"""A collection of helper/utility functions for processing text.
+"""
+import re
+
+from spacy.tokenizer import Tokenizer
+
+# NERsuite-like tokenization: alnum sequences preserved as single
+# tokens, rest are single-character tokens.
+# https://github.com/spyysalo/standoff2conll/blob/master/common.py
+INFIX_RE = re.compile(r'''([0-9a-zA-Z]+|[^0-9a-zA-Z])''')
+
+def biomedical_tokenizer(nlp):
+    return Tokenizer(nlp.vocab, infix_finditer=INFIX_RE.finditer)


### PR DESCRIPTION
This pull request adds a small modification to the default Spacy tokenizer in order to more closely match the tokenization scheme of the data the model was trained on. This should lead to better performance downstream.

Essentially, the only change is that the tokenizer is now much more fine-grained. All alphanumeric sequences are preserved a single tokens, but everything else is split into single-character tokens (e.g. '-', '/', etc are all split).