### PR TITLE
Allow for installation with test suite check

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,24 +88,21 @@ $ source activate saber
 
 ## Running tests
 
-Sabers test suite can be found in `saber/tests`. In order to run the tests, you'll usually want to clone the repository locally. Make sure to install all required development dependencies defined in ``requirements.txt``. Additionally, you will need to install ``pytest``:
+Sabers test suite can be found in `saber/tests`. If Saber is already installed, you can run `pytest` on the installation directory:
 
 ```
+# Install pytest
 (saber) $ pip install pytest
-```
-
-To run the tests:
-
-```
-(saber) $ cd path/to/saber
-(saber) $ py.test saber
-```
-
-Alternatively, you can find out where Saber is installed and run `pytest` on that directory:
-
-```
 # Find out where Saber is installed
-(saber) $ python -c "import os; import saber; print(os.path.dirname(saber.__file__))"
+(saber) $ INSTALL_DIR=$(python -c "import os; import saber; print(os.path.dirname(saber.__file__))")
 # Run tests on that installation directory
-(saber) $ python -m pytest <Saber-directory>
+(saber) $ python -m pytest $INSTALL_DIR
+```
+
+Alternatively, to clone Saber, install it, and run the test suite all in one go:
+
+```
+(saber) $ git clone https://github.com/BaderLab/saber.git
+(saber) $ cd saber
+(saber) $ python setup.py test
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="Saber",
+    name="saber",
     version="0.0.1",
     author="John Giorgi",
     author_email="johnmgiorgi@gmail.com",
@@ -33,4 +33,8 @@ setuptools.setup(
         'gensim>=3.4.0'
     ],
     include_package_data=True,
+    # allows us to install + run tests with `python setup.py test`
+    # https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         'tensorflow>=1.9.0',
         'Flask>=1.0.2',
         'waitress>=1.1.0',
-        'keras==2.2.0',
+        'keras>=2.2.0',
         'PTable>=0.9.2',
         'spacy>=2.0.11',
         'gensim>=3.4.0'


### PR DESCRIPTION
Small pull request that allows you to install saber and run the test suit from a cloned repository all in one go:

```
git clone https://github.com/BaderLab/saber.git
cd saber
python setup.py test
```

Installing this way allows you to verify the install went smoothly.

Closes #37.