### PR TITLE
User can now specify config filepath at command line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6
 WORKDIR /app
-ADD . /app
+COPY . /app
 RUN pip install .
 #RUN pip install git+https://github.com/BaderLab/saber.git
 RUN pip install git+https://www.github.com/keras-team/keras-contrib.git

--- a/saber/config.py
+++ b/saber/config.py
@@ -34,11 +34,11 @@ class Config(object):
         self.filepath = self._get_filepath(filepath, self.cli_args)
         self.config = self._parse_config(self.filepath)
 
-        # harmonzing cli and config file arguments
+        # harmonizing cli and config file arguments
         self._process_args(self.cli_args)
 
     def save(self, directory):
-        """Saves the harmonzied args sourced from the *.ini file and the command line to filepath.
+        """Saves the harmonized args sourced from the *.ini file and the command line to filepath.
 
         Saves a config.ini file at filepath, containing the harmonized arguments sourced from the
         original config file at `self.config` and any arguments supplied at the command line.
@@ -85,7 +85,7 @@ class Config(object):
         return config
 
     def _process_args(self, cli_args):
-        """Collect arguments from *.ini file if specificed.
+        """Collect arguments from *.ini file if specified.
 
         Loads parameters from ConfigParser object at 'self.config'. Any identically named arguments
         provided at the command line (provided to this method as a dictionary in `cli_args`) will
@@ -224,7 +224,8 @@ class Config(object):
         """
         parser = argparse.ArgumentParser(description='Saber CLI.')
 
-        parser.add_argument('--config_filepath', required=False, default='config.ini', type=str,
+        parser.add_argument('--config_filepath', required=False, type=str,
+                            default=resource_filename(__name__, constants.CONFIG_FILENAME),
                             help='Path to the *.ini file containing any arguments')
         parser.add_argument('--activation', required=False, type=str,
                             help=("Activation function to use in the dense layers. Defaults to "
@@ -250,7 +251,7 @@ class Config(object):
                                   'certain optimizers this value is ignored. Defaults to 0.'))
         parser.add_argument('--dropout_rate', required=False, nargs=3, type=float,
                             metavar=('input', 'output', 'recurrent'),
-                            help=('Expects three values, seperated by a space, which specify the '
+                            help=('Expects three values, separated by a space, which specify the '
                                   'fraction of units to drop for input, output and recurrent '
                                   'connections respectively. Values must be between 0 and 1.'))
         parser.add_argument('--fine_tune_word_embeddings', required=False, action='store_true',

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -41,6 +41,7 @@ PRETRAINED_MODEL_DIR = resource_filename(__name__, 'pretrained_models')
 MODEL_FILENAME = 'model_params.json'
 WEIGHTS_FILENAME = 'model_weights.hdf5'
 ATTRIBUTES_FILENAME = 'attributes.pickle'
+CONFIG_FILENAME = 'config.ini'
 
 # MODEL SETTINGS
 # batch size to use when performing model prediction
@@ -67,7 +68,7 @@ ENTITIES = {'ANAT': False,
             'PRGE': True,
             'TRIG': False}
 # CONFIG
-CONFIG_ARGS = ['model_name', 'dataset_folder', 'output_folder',
+CONFIG_ARGS = ['model_name', 'save_model', 'dataset_folder', 'output_folder',
                'pretrained_model_weights', 'pretrained_embeddings', 'word_embed_dim',
                'char_embed_dim', 'optimizer', 'activation', 'learning_rate', 'decay', 'grad_norm',
                'dropout_rate', 'batch_size', 'k_folds', 'epochs', 'criteria', 'verbose',

--- a/saber/models/multi_task_lstm_crf.py
+++ b/saber/models/multi_task_lstm_crf.py
@@ -1,10 +1,8 @@
 """Contains the Multi-task BiLSTM-CRF (MT-BILSTM-CRF) Keras model for squence labelling.
 """
-import json
 import logging
 
 import tensorflow as tf
-from keras import initializers
 from keras.layers import (LSTM, Bidirectional, Concatenate, Dense, Dropout,
                           Embedding, SpatialDropout1D, TimeDistributed)
 from keras.models import Input, Model, model_from_json
@@ -12,7 +10,6 @@ from keras.utils import multi_gpu_model
 from keras_contrib.layers.crf import CRF
 
 from .. import constants
-from ..utils import model_utils
 from .base_model import BaseKerasModel
 
 LOGGER = logging.getLogger(__name__)

--- a/saber/saber.py
+++ b/saber/saber.py
@@ -20,6 +20,7 @@ from .utils import data_utils, generic_utils, grounding_utils, model_utils
 print('Saber version: {0}'.format(constants.__version__))
 LOGGER = logging.getLogger(__name__)
 
+
 class Saber(object):
     """The interface for Saber.
 
@@ -27,12 +28,12 @@ class Saber(object):
     training, saving, and loading of sequence labelling models.
 
     Args:
-        config (Config): A Config object which contains a set of harmonzied arguments provided in
+        config (Config): A Config object which contains a set of harmonized arguments provided in
             a *.ini file and, optionally, from the command line. If not provided, a new instance of
             Config is used.
     """
     def __init__(self, config=None, **kwargs):
-        self.config = config if config is not None else Config()
+        self.config = Config() if config is None else config
 
         self.preprocessor = None # object for text processing
         self.datasets = None # dataset(s) tied to this instance
@@ -52,7 +53,7 @@ class Saber(object):
 
         For the model at `self.model.models[model_idx]`, coordinates a prediction step on `text`.
         Returns a dictionary containing the cleaned text (`text`), and any annotations made by the
-        model (`ents`). If `jupyter` is True, renders a HTMl visulization of the annotations made
+        model (`ents`). If `jupyter` is True, renders a HTMl visualization of the annotations made
         by the model, for use in a jupyter notebook.
 
         text (str): Raw text to annotate.
@@ -118,7 +119,7 @@ class Saber(object):
     def save(self, directory=None, compress=True, model_idx=0):
         """Coordinates the saving of Saber models.
 
-        Saves the necessary files for model persistance to `directory`. If not provided, `directory`
+        Saves the necessary files for model persistence to `directory`. If not provided, `directory`
         defaults to '<self.config.output_folder>/<constants.PRETRAINED_MODEL_DIR>/<dataset_names>'
 
         Args:

--- a/saber/tests/test_base_model.py
+++ b/saber/tests/test_base_model.py
@@ -1,14 +1,13 @@
 """Any and all unit tests for the BaseKerasModel (saber/models/base_model.py).
 """
-from keras.engine.training import Model
-
 import pytest
 
+from .resources.dummy_constants import *
 from ..config import Config
 from ..dataset import Dataset
 from ..embeddings import Embeddings
 from ..models.base_model import BaseKerasModel
-from .resources.dummy_constants import *
+
 
 ######################################### PYTEST FIXTURES #########################################
 

--- a/saber/tests/test_base_model.py
+++ b/saber/tests/test_base_model.py
@@ -2,12 +2,11 @@
 """
 import pytest
 
-from .resources.dummy_constants import *
 from ..config import Config
 from ..dataset import Dataset
 from ..embeddings import Embeddings
 from ..models.base_model import BaseKerasModel
-
+from .resources.dummy_constants import *
 
 ######################################### PYTEST FIXTURES #########################################
 

--- a/saber/tests/test_config.py
+++ b/saber/tests/test_config.py
@@ -1,35 +1,35 @@
-"""Contains any and all unit tests for the Config class (saber/config.py).
+"""Contains any and all unit tests for the config.Config class (saber/config.py).
 """
 import configparser
-import os
 
 import pytest
 
-from ..config import Config
 from .resources.dummy_constants import *
+from .. import config
+
 
 ######################################### PYTEST FIXTURES #########################################
 
 @pytest.fixture
 def config_no_cli_args():
-    """Returns an instance of a Config object after parsing the dummy config file with no command
+    """Returns an instance of a config.Config object after parsing the dummy config file with no command
     line interface (CLI) args."""
     # the dataset and embeddings are used for test purposes so they must point to the
     # correct resources, this can be ensured by passing their paths here
     cli_arguments = {'dataset_folder': [PATH_TO_DUMMY_DATASET_1],
                      'pretrained_embeddings': PATH_TO_DUMMY_EMBEDDINGS}
     # parse the dummy config
-    dummy_config = Config(PATH_TO_DUMMY_CONFIG)
+    dummy_config = config.Config(PATH_TO_DUMMY_CONFIG)
     dummy_config._process_args(cli_arguments)
 
     return dummy_config
 
 @pytest.fixture
 def config_with_cli_args():
-    """Returns an instance of a Config object after parsing the dummy config file with command line
+    """Returns an instance of a config.config.Config object after parsing the dummy config file with command line
     interface (CLI) args."""
     # parse the dummy config, leave cli false and instead pass command line args manually
-    dummy_config = Config(PATH_TO_DUMMY_CONFIG)
+    dummy_config = config.Config(PATH_TO_DUMMY_CONFIG)
     # this is a bit of a hack, but need to simulate providing commands at the command line
     dummy_config.cli_args = DUMMY_COMMAND_LINE_ARGS
     dummy_config._process_args(DUMMY_COMMAND_LINE_ARGS)
@@ -39,7 +39,7 @@ def config_with_cli_args():
 ############################################ UNIT TESTS ############################################
 
 def test_process_args_no_cli_args(config_no_cli_args):
-    """Asserts the Config.config object contains the expected attributes after initializing a Config
+    """Asserts the config.Config.config object contains the expected attributes after initializing a config.Config
     object without CLI args."""
     # check filepath attribute
     assert config_no_cli_args.filepath == PATH_TO_DUMMY_CONFIG
@@ -52,7 +52,7 @@ def test_process_args_no_cli_args(config_no_cli_args):
     assert config_no_cli_args.cli_args == {}
 
 def test_process_args_with_cli_args(config_with_cli_args):
-    """Asserts the Config.config object contains the expected attributes after initializing a Config
+    """Asserts the config.Config.config object contains the expected attributes after initializing a config.Config
     object with CLI args."""
     # check filepath attribute
     assert config_with_cli_args.filepath == os.path.join(os.path.dirname( \
@@ -66,7 +66,7 @@ def test_process_args_with_cli_args(config_with_cli_args):
     assert config_with_cli_args.cli_args == DUMMY_COMMAND_LINE_ARGS
 
 def test_config_attributes_no_cli_args(config_no_cli_args):
-    """Asserts that the class attributes of a Config object are of the expected value/type after
+    """Asserts that the class attributes of a config.Config object are of the expected value/type after
     objects initialization, with NO command line arguments.
     """
     # check that we get the values we expected
@@ -74,7 +74,7 @@ def test_config_attributes_no_cli_args(config_no_cli_args):
         assert value == getattr(config_no_cli_args, arg)
 
 def test_config_attributes_with_cli_args(config_with_cli_args):
-    """Asserts that the class attributes of a Config object are of the expected value/type after
+    """Asserts that the class attributes of a config.Config object are of the expected value/type after
     object initialization, taking into account command line arguments, which take precedence over
     config arguments.
     """
@@ -82,6 +82,32 @@ def test_config_attributes_with_cli_args(config_with_cli_args):
     # have overwritten our config arguments
     for arg, value in DUMMY_ARGS_WITH_CLI_ARGS.items():
         assert value == getattr(config_with_cli_args, arg)
+
+
+def test_get_filepath(config_no_cli_args):
+    """Asserts that `Config._get_filepath()` returns the expected values.
+    """
+    # tests for when neither filepath nor cli_args arguments are provided
+    filepath_none_cli_args_none_expected = resource_filename(config.__name__, constants.CONFIG_FILENAME)
+    filepath_none_cli_args_none_actual = config_no_cli_args._get_filepath(filepath=None, cli_args={})
+    # tests for when cli_args argument is provided
+    filepath_none_cli_args_expected = 'arbitrary/filepath/to/config.ini'
+    dummy_cli_args = {'config_filepath': filepath_none_cli_args_expected}
+    filepath_none_cli_args_actual = config_no_cli_args._get_filepath(filepath=None,
+                                                                     cli_args=dummy_cli_args)
+    # tests for when filepath argument is provided
+    filepath_cli_args_none_expected = filepath_none_cli_args_expected
+    filepath_cli_args_none_actual = config_no_cli_args._get_filepath(filepath=filepath_cli_args_none_expected,
+                                                                     cli_args={})
+    # tests for when both filepath and cli_args arguments are provided
+    filepath_cli_args_expected = filepath_none_cli_args_expected
+    filepath_cli_args_actual = config_no_cli_args._get_filepath(filepath=filepath_cli_args_expected,
+                                                                cli_args=dummy_cli_args)
+
+    assert filepath_none_cli_args_none_expected == filepath_none_cli_args_none_actual
+    assert filepath_none_cli_args_expected == filepath_none_cli_args_actual
+    assert filepath_cli_args_none_expected == filepath_cli_args_none_actual
+    assert filepath_cli_args_expected == filepath_cli_args_actual
 
 def test_save_no_cli_args(config_no_cli_args, tmpdir):
     """Asserts that a saved config file contains the correct arguments and values."""
@@ -114,13 +140,13 @@ def test_save_with_cli_args(config_with_cli_args, tmpdir):
 ######################################### HELPER FUNCTIONS #########################################
 
 def load_saved_config(filepath):
-    """Load a saved ConfigParser object at 'filepath/config.ini'.
+    """Load a saved config.ConfigParser object at 'filepath/config.ini'.
 
     Args:
         filepath (str): filepath to the saved config file 'config.ini'
 
     Returns:
-        parsed ConfigParser object at 'filepath/config.ini'.
+        parsed config.ConfigParser object at 'filepath/config.ini'.
     """
     saved_config_filepath = os.path.join(filepath, 'config.ini')
     saved_config = configparser.ConfigParser()

--- a/saber/tests/test_saber.py
+++ b/saber/tests/test_saber.py
@@ -70,7 +70,7 @@ def dummy_config_compound_dataset():
     compound_dataset = [PATH_TO_DUMMY_DATASET_1, PATH_TO_DUMMY_DATASET_2]
     cli_arguments = {'dataset_folder': compound_dataset}
     dummy_config = Config(PATH_TO_DUMMY_CONFIG)
-    dummy_config._process_args(cli_arguments)
+    dummy_config.harmonize_args(cli_arguments)
 
     return dummy_config
 


### PR DESCRIPTION
Fixes an issue where a config file (`*.ini`) had no effect when passed as a command line argument (`config_filepath`). A config passed at the command line now takes precedence over the default config file.

Closes #19.