### PR TITLE
Add support for python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - os: osx
 
 python:
+  - "3.5"
   - "3.6"
 
 branches:

--- a/saber/tests/test_config.py
+++ b/saber/tests/test_config.py
@@ -107,14 +107,14 @@ def test_key_error(tmpdir):
     `filepath` that does does contain a valid *.ini file.
     """
     with pytest.raises(KeyError):
-        dummy_config = config.Config(tmpdir)
+        dummy_config = config.Config(tmpdir.strpath)
 
 def test_save_no_cli_args(config_no_cli_args, tmpdir):
     """Asserts that a saved config file contains the correct arguments and values."""
     # save the config to temporary directory created by py.test
-    config_no_cli_args.save(tmpdir)
+    config_no_cli_args.save(tmpdir.strpath)
     # load the saved config
-    saved_config = load_saved_config(tmpdir)
+    saved_config = load_saved_config(tmpdir.strpath)
     # need to 'unprocess' the args to check them against the saved config file
     unprocessed_args = unprocess_args(DUMMY_ARGS_NO_CLI_ARGS)
     # ensure the saved config file matches the original arguments used to create it
@@ -127,9 +127,9 @@ def test_save_with_cli_args(config_with_cli_args, tmpdir):
     account command line arguments, which take precedence over config arguments.
     """
     # save the config to temporary directory created by py.test
-    config_with_cli_args.save(tmpdir)
+    config_with_cli_args.save(tmpdir.strpath)
     # load the saved config
-    saved_config = load_saved_config(tmpdir)
+    saved_config = load_saved_config(tmpdir.strpath)
     # need to 'unprocess' the args to check them against the saved config file
     unprocessed_args = unprocess_args(DUMMY_ARGS_WITH_CLI_ARGS)
     # ensure the saved config file matches the original arguments used to create it

--- a/saber/tests/test_data_utils.py
+++ b/saber/tests/test_data_utils.py
@@ -61,7 +61,7 @@ def dummy_dataset_paths_all(tmpdir_factory):
     test_file = dummy_dir.join('test.tsv')
     test_file.write('arbitrary')
 
-    return dummy_dir, train_file, valid_file, test_file
+    return dummy_dir.strpath, train_file.strpath, valid_file.strpath, test_file.strpath
 
 @pytest.fixture(scope='session')
 def dummy_dataset_paths_no_valid(tmpdir_factory):
@@ -75,7 +75,7 @@ def dummy_dataset_paths_no_valid(tmpdir_factory):
     test_file = dummy_dir.join('test.tsv')
     test_file.write('arbitrary')
 
-    return dummy_dir, train_file, test_file
+    return dummy_dir.strpath, train_file.strpath, test_file.strpath
 
 ############################################ UNIT TESTS ############################################
 
@@ -84,7 +84,7 @@ def test_get_filepaths_value_error(tmpdir):
     no file '<tmpdir>/train.*' exists.
     """
     with pytest.raises(ValueError):
-        data_utils.get_filepaths(tmpdir)
+        data_utils.get_filepaths(tmpdir.strpath)
 
 def test_get_filepaths_all(dummy_dataset_paths_all):
     """Asserts that `data_utils.get_filepaths()` returns the expected filepaths when all partitions

--- a/saber/tests/test_generic_utils.py
+++ b/saber/tests/test_generic_utils.py
@@ -15,7 +15,7 @@ def dummy_dir(tmpdir_factory):
     """Returns the path to a temporary directory.
     """
     dummy_dir = tmpdir_factory.mktemp('dummy_dir')
-    return dummy_dir
+    return dummy_dir.strpath
 
 @pytest.fixture
 def dummy_config():
@@ -142,7 +142,7 @@ def test_make_dir_new(tmpdir):
     """Assert that `generic_utils.make_dir()` creates a directory as expected when it does not
     already exist.
     """
-    dummy_dirpath = os.path.join(tmpdir, 'dummy_dir')
+    dummy_dirpath = os.path.join(tmpdir.strpath, 'dummy_dir')
     generic_utils.make_dir(dummy_dirpath)
     assert os.path.isdir(dummy_dirpath)
 

--- a/saber/tests/test_metrics.py
+++ b/saber/tests/test_metrics.py
@@ -33,7 +33,7 @@ def dummy_dataset():
 def dummy_output_dir(tmpdir, dummy_config):
     """Returns list of output directories."""
     # make sure top-level directory is the pytest tmpdir
-    dummy_config.output_folder = tmpdir
+    dummy_config.output_folder = tmpdir.strpath
     output_dirs = model_utils.prepare_output_directory(dummy_config)
 
     return output_dirs

--- a/saber/tests/test_model_utils.py
+++ b/saber/tests/test_model_utils.py
@@ -21,7 +21,7 @@ def dummy_config():
 def dummy_output_dir(tmpdir, dummy_config):
     """Returns list of output directories."""
     # make sure top-level directory is the pytest tmpdir
-    dummy_config.output_folder = tmpdir
+    dummy_config.output_folder = tmpdir.strpath
     output_dirs = model_utils.prepare_output_directory(dummy_config)
 
     return output_dirs

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/BaderLab/saber",
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     packages=setuptools.find_packages(),
     classifiers=(
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Essentially just involves updating the `setup.py` file. But for future reference, when using the `tmpdir` pytest fixture, make sure to use `tmpdir.strpath` to actually access the string version of the filepath. For some reason, using just `tmdir` on its own throws errors in python3.5 (but not python3.6).

I will update the documentation to reflect this change to python version in another pull request.

Closes #82.