### PR TITLE
Load all embeddings

### DIFF
--- a/docs/guide_to_saber_api.md
+++ b/docs/guide_to_saber_api.md
@@ -17,7 +17,7 @@ along with any command line arguments. For example, to train the model on the [N
 ```
 
 !!! tip
-    See [Resources](https://baderlab.github.io/saber/resources/) for help preparing datasets for training.
+    See [Resources](https://baderlab.github.io/saber/resources/) for help preparing datasets and word embeddings for training.
 
 Run `python -m saber.cli.train --help` to see all possible arguments.
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -59,6 +59,21 @@ $ mkdir path/to/word_embeddings
 $ wget http://evexdb.org/pmresources/vec-space-models/wikipedia-pubmed-and-PMC-w2v.bin -O path/to/word_embeddings
 ```
 
+To use these word embeddings with Saber, provide their path in the `pretrained_embeddings` argument (either in the `config` file or at the command line). Alternatively, you their path to `Saber.load_embeddings()`. For example:
+
+```python
+from saber.saber import Saber
+
+saber = Saber()
+
+saber.load_dataset('path/to/dataset')
+# load the embeddings here
+saber.load_embeddings('path/to/word_embeddings')
+
+saber.build()
+saber.train()
+```
+
 ### GloVe
 
 To use [GloVe](https://nlp.stanford.edu/projects/glove/) embeddings, just convert them to the [word2vec](https://code.google.com/archive/p/word2vec/) format first:

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -59,7 +59,7 @@ $ mkdir path/to/word_embeddings
 $ wget http://evexdb.org/pmresources/vec-space-models/wikipedia-pubmed-and-PMC-w2v.bin -O path/to/word_embeddings
 ```
 
-To use these word embeddings with Saber, provide their path in the `pretrained_embeddings` argument (either in the `config` file or at the command line). Alternatively, you their path to `Saber.load_embeddings()`. For example:
+To use these word embeddings with Saber, provide their path in the `pretrained_embeddings` argument (either in the `config` file or at the command line). Alternatively, pass their path to `Saber.load_embeddings()`. For example:
 
 ```python
 from saber.saber import Saber

--- a/saber/config.ini
+++ b/saber/config.ini
@@ -55,16 +55,21 @@ criteria = exact
 [advanced]
 verbose = False
 debug = False
-# If True, then during training the models weights for each and every epoch will be saved.
-# Otherwise, weights are only saved for epochs that achieve a new best on validation loss.
-save_all_weights = False
 # If True, per-epoch logs which can be visualized with TensorBoard are written to output_folder
 # Note: These logs can be quite large.
 tensorboard = False
+# If True, then during training the models weights for each and every epoch will be saved.
+# Otherwise, weights are only saved for epochs that achieve a new best on validation loss.
+save_all_weights = False
 # If True, tokens that occur less than 1 time in the training dataset (hapax legomenon) are replaced
 # with a special unknown token. This should result in faster loading times of pre-trained word
 # embeddings and faster training times.
 replace_rare_tokens = True
+# If True, then all pre-trained word embeddings provided via pretrained_embeddings are loaded.
+# Otherwise, only pre-trained embeddings for tokens found in the dataset(s) at dataset_folder are
+# loaded. For evaluation, it's best to leave this as False. For models that will be deployed, it's
+# best to set it to True.
+load_all_embeddings = False
 # If True, then pre-trained word embeddings will be fine-tuned with the other parameters of the
 # neural network during training. Generally, you should not set this to True unless you have a very
 # large training dataset.

--- a/saber/config.py
+++ b/saber/config.py
@@ -88,6 +88,7 @@ class Config(object):
         for arg, value in args.items():
             setattr(self, arg, value)
 
+    @classmethod
     def _load_config(self, filepath):
         """Returns a parsed ConfigParser object for config file at 'filepath'.
 
@@ -102,6 +103,7 @@ class Config(object):
 
         return config
 
+    @classmethod
     def _resolve_filepath(self, filepath, cli_args):
         """Return appropriate filepath based on how Config class was invoked.
 
@@ -179,6 +181,7 @@ class Config(object):
 
         return args
 
+    @classmethod
     def _post_process_config_args(self, args):
         """Post process parameters retried from python config file.
 
@@ -212,6 +215,7 @@ class Config(object):
 
         return args
 
+    @classmethod
     def _parse_cli_args(self):
         """Parse command line arguments passed with call to Saber CLI.
 

--- a/saber/config.py
+++ b/saber/config.py
@@ -160,9 +160,10 @@ class Config(object):
             # advanced
             args['verbose'] = config['advanced'].getboolean('verbose')
             args['debug'] = config['advanced'].getboolean('debug')
-            args['save_all_weights'] = config['advanced'].getboolean('save_all_weights')
             args['tensorboard'] = config['advanced'].getboolean('tensorboard')
+            args['save_all_weights'] = config['advanced'].getboolean('save_all_weights')
             args['replace_rare_tokens'] = config['advanced'].getboolean('replace_rare_tokens')
+            args['load_all_embeddings'] = config['advanced'].getboolean('load_all_embeddings')
             args['fine_tune_word_embeddings'] = config['advanced'].getboolean('fine_tune_word_embeddings')
             # TEMP
             args['variational_dropout'] = config['advanced'].getboolean('variational_dropout')
@@ -260,6 +261,10 @@ class Config(object):
         parser.add_argument('--learning_rate', required=False, type=float,
                             help=('float >= 0. Learning rate. Note that for certain optimizers '
                                   'this value is ignored'))
+        parser.add_argument('--load_all_embeddings', required=False, action='store_true',
+                            help=('Pass this argument if all pre-trained embeddings should be '
+                                  'loaded, and not just those found in the dataset(s). Has no '
+                                  'effect if --pretrained_embeddings argument is empty.'))
         parser.add_argument('--epochs', required=False, type=int,
                             help=('Integer. Number of epochs to train the model. An epoch is an '
                                   'iteration over all data provided.'))

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -73,4 +73,4 @@ CONFIG_ARGS = ['model_name', 'save_model', 'dataset_folder', 'output_folder',
                'char_embed_dim', 'optimizer', 'activation', 'learning_rate', 'decay', 'grad_norm',
                'dropout_rate', 'batch_size', 'k_folds', 'epochs', 'criteria', 'verbose',
                'debug', 'save_all_weights', 'tensorboard', 'replace_rare_tokens',
-               'fine_tune_word_embeddings', 'variational_dropout']
+               'load_all_embeddings', 'fine_tune_word_embeddings', 'variational_dropout']

--- a/saber/dataset.py
+++ b/saber/dataset.py
@@ -74,7 +74,7 @@ class Dataset(object):
         # unique words, chars and tags from CoNLL formatted dataset
         types = self._get_types()
         # map each word, char, and tag type to a unique integer
-        self.get_idx_maps(types)
+        self._get_idx_maps(types)
 
         # get word, char, and tag sequences from CoNLL formatted dataset
         self._get_type_seq()
@@ -135,7 +135,7 @@ class Dataset(object):
                 # update the class attributes
                 self.type_seq[partition] = {'word': word_seq, 'char': char_seq, 'tag': tag_seq}
 
-    def get_idx_maps(self, types, initial_mapping=None):
+    def _get_idx_maps(self, types, initial_mapping=None):
         """Updates `self.type_to_idx` with mappings from word, char and tag types to unique int IDs.
         """
         initial_mapping = constants.INITIAL_MAPPING if initial_mapping is None else initial_mapping

--- a/saber/embeddings.py
+++ b/saber/embeddings.py
@@ -105,6 +105,7 @@ class Embeddings(object):
 
         return embedding_matrix, type_to_idx
 
+    @classmethod
     def _generate_type_to_idx(self, embedding_idx):
         """Returns a dictionary mapping tokens in  `embedding_idx` to unique integer IDs.
         """

--- a/saber/embeddings.py
+++ b/saber/embeddings.py
@@ -3,6 +3,9 @@
 import numpy as np
 from gensim.models import KeyedVectors
 
+from . import constants
+from .preprocessor import Preprocessor
+
 
 class Embeddings(object):
     """A class for loading and working with pre-trained word embeddings.
@@ -15,33 +18,38 @@ class Embeddings(object):
         self.filepath = filepath
         self.token_map = token_map
 
-        self.matrix = None # token embeddings tied to this instance
-        self.num_loaded = None # number of loaded embeddings
+        self.matrix = None # matrix containing row vectors for all embedded tokens
+        self.num_found = None # number of loaded embeddings
         self.num_embed = None # final count of embedded words
         self.dimension = None # dimension of these embeddings
 
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-    def load(self, binary=True):
+    def load(self, binary=True, load_all=False):
         """Coordinates the loading of pre-trained word embeddings.
 
         Creates an embedding matrix from the pre-trained word embeddings given at `self.filepath`,
         whose ith row corresponds to the word embedding for the word with value i in
-        `self.token_map`. Updates the instance attributes `self.matrix, `self.num_loaded`,
+        `self.token_map`. Updates the instance attributes `self.matrix, `self.num_found`,
         `self.dimension`, and `self.num_embed`.
 
         Args:
             binary (bool): True if pre-trained embeddings are in C binary format, False if they are
                 in C text format. Defaults to True.
+            load_all (bool): True if all embeddings should be loaded. False if only words that
+            appear in `self.token_map` should be loaded. Defaults to False.
+
+        Returns:
+            The token map used to map the embeddings to an embedding matrix.
         """
         # prepare the embedding indices
         embedding_idx = self._prepare_embedding_index(binary)
-        self.num_loaded, self.dimension = len(embedding_idx), len(list(embedding_idx.values())[0])
-        self.matrix = self._prepare_embedding_matrix(embedding_idx)
+        self.num_found, self.dimension = len(embedding_idx), len(list(embedding_idx.values())[0])
+        self.matrix, type_to_idx = self._prepare_embedding_matrix(embedding_idx, load_all)
         self.num_embed = self.matrix.shape[0] # num of embedded words
 
-        return True
+        return type_to_idx
 
     def _prepare_embedding_index(self, binary=True):
         """Returns an embedding index for pre-trained token embeddings.
@@ -63,7 +71,7 @@ class Embeddings(object):
 
         return embedding_idx
 
-    def _prepare_embedding_matrix(self, embedding_idx):
+    def _prepare_embedding_matrix(self, embedding_idx, load_all=False):
         """Returns an embedding matrix containing all pre-trained embeddings in `embedding_idx`.
 
         Creates an embedding matrix from `embedding_idx`, where the ith row contains the
@@ -72,11 +80,19 @@ class Embeddings(object):
 
         Args:
             embedding_idx (dict): A Dictionary mapping words to their embeddings.
+            load_all (bool): True if all embeddings should be loaded. False if only words that
+            appear in `self.token_map` should be loaded. Defaults to False.
 
         Returns:
             A matrix whos ith row corresponds to the word embedding for the word with value i in
             `self.token_map`.
         """
+        type_to_idx = None
+        if load_all:
+            # overwrite provided token map
+            type_to_idx = self._generate_type_to_idx(embedding_idx)
+            self.token_map = type_to_idx['word']
+
         # initialize the embeddings matrix
         embedding_matrix = np.zeros((len(self.token_map), self.dimension))
 
@@ -87,4 +103,19 @@ class Embeddings(object):
                 # words not found in embedding index will be all-zeros.
                 embedding_matrix[i] = token_embedding
 
-        return embedding_matrix
+        return embedding_matrix, type_to_idx
+
+    def _generate_type_to_idx(self, embedding_idx):
+        """Returns a dictionary mapping tokens in  `embedding_idx` to unique integer IDs.
+        """
+        word_types, char_types = list(embedding_idx.keys()), []
+        for word in word_types:
+            char_types.extend(list(word))
+        char_types = list(set(char_types))
+
+        type_to_idx = {
+            'word': Preprocessor.type_to_idx(word_types, constants.INITIAL_MAPPING['word']),
+            'char': Preprocessor.type_to_idx(char_types, constants.INITIAL_MAPPING['word'])
+        }
+
+        return type_to_idx

--- a/saber/saber.py
+++ b/saber/saber.py
@@ -246,7 +246,7 @@ class Saber(object):
         end = time.time() - start
         print('Done ({0:.2f} seconds).'.format(end))
 
-    def load_embeddings(self, filepath=None, binary=True):
+    def load_embeddings(self, filepath=None, binary=True, load_all=None):
         """Coordinates the loading of pre-trained token embeddings.
 
         Args:
@@ -254,6 +254,8 @@ class Saber(object):
                 'self.config.pretrained_embeddings'.
             binary (bool): True if pre-trained embeddings are in C binary format, False if they are
                 in C text format.
+            load_all (bool): True if all pre-trained embeddings should be loaded. Otherwise only
+                embeddings for tokens found in the training set are loaded. Defaults to None.
 
         Raises:
             MissingStepException: If no dataset has been loaded.
@@ -262,9 +264,13 @@ class Saber(object):
         start = time.time()
         print('Loading embeddings...', end=' ', flush=True)
 
+        # allow user to provide select args in function call
+        if load_all is not None:
+            self.config.load_all_embeddings = load_all
         if filepath is not None:
             filepath = generic_utils.clean_path(filepath)
             self.config.pretrained_embeddings = filepath
+
         if not self.datasets:
             err_msg = "You need to call `load_dataset()` before calling `load_embeddings()`"
             LOGGER.error('MissingStepException: %s', err_msg)

--- a/saber/saber.py
+++ b/saber/saber.py
@@ -290,8 +290,10 @@ class Saber(object):
         if self.config.load_all_embeddings:
             type_to_idx = self.embeddings.load(binary, load_all=self.config.load_all_embeddings)
             for dataset in self.datasets:
-                dataset.type_to_idx['word'].update(type_to_idx['word'])
-                dataset.type_to_idx['char'].update(type_to_idx['char'])
+                word_types = list(dataset.type_to_idx['word'])
+                char_types = list(dataset.type_to_idx['char'])
+                dataset.type_to_idx['word'] = Preprocessor.type_to_idx(word_types, type_to_idx['word'])
+                dataset.type_to_idx['char'] = Preprocessor.type_to_idx(char_types, type_to_idx['char'])
                 dataset.get_idx_seq()
         else:
             self.embeddings.load(binary)

--- a/saber/tests/resources/dummy_config.ini
+++ b/saber/tests/resources/dummy_config.ini
@@ -55,16 +55,21 @@ criteria = exact
 [advanced]
 verbose = False
 debug = False
-# If True, then during training the models weights for each and every epoch will be saved.
-# Otherwise, weights are only saved for epochs that achieve a new best on validation loss.
-save_all_weights = False
 # If True, per-epoch logs which can be visualized with TensorBoard are written to output_folder
 # Note: These logs can be quite large.
 tensorboard = False
+# If True, then during training the models weights for each and every epoch will be saved.
+# Otherwise, weights are only saved for epochs that achieve a new best on validation loss.
+save_all_weights = False
 # If True, tokens that occur less than 1 time in the training dataset (hapax legomenon) are replaced
 # with a special unknown token. This should result in faster loading times of pre-trained word
 # embeddings and faster training times.
 replace_rare_tokens = False
+# If True, then all pre-trained word embeddings provided via pretrained_embeddings are loaded.
+# Otherwise, only pre-trained embeddings for tokens found in the dataset(s) at dataset_folder are
+# loaded. For evaluation, it's best to leave this as False. For models that will be deployed, it's
+# best to set it to True.
+load_all_embeddings = False
 # If True, then pre-trained word embeddings will be fine-tuned with the other parameters of the
 # neural network during training. Generally, you should not set this to True unless you have a very
 # large training dataset.

--- a/saber/tests/resources/dummy_constants.py
+++ b/saber/tests/resources/dummy_constants.py
@@ -19,7 +19,9 @@ PATH_TO_DUMMY_EMBEDDINGS = resource_filename(__name__, 'dummy_word_embeddings/du
 ######################################### DUMMY EMBEDDINGS #########################################
 
 # for testing embeddings
-DUMMY_TOKEN_MAP = {'the': 0, 'quick': 1, 'brown': 2, 'fox': 3}
+DUMMY_TOKEN_MAP = {'<PAD>': 0, '<UNK>': 1, 'the': 2, 'quick': 3, 'brown': 4, 'fox': 5}
+DUMMY_CHAR_MAP = {'<PAD>': 0, '<UNK>': 1, 'r': 2, 'u': 3, 'c': 4, 'f': 5, 'e': 6, 'o': 7, 'x': 8,
+                  'h': 9, 'b': 10, 'n': 11, 'w': 12, 'i': 13, 't': 14, 'q': 15, 'k': 16}
 DUMMY_EMBEDDINGS_INDEX = {
     'the': [0.15580128, -0.07108746, 0.055198, -0.14199848, 0.0005317868],
     'quick': [-0.011208724, 0.21213274, -0.17233513, -0.4401193, 0.13930725],
@@ -27,6 +29,8 @@ DUMMY_EMBEDDINGS_INDEX = {
     'fox': [0.2947119, 0.14794342, 0.10318808, 0.09019197, -0.24244581]
 }
 DUMMY_EMBEDDINGS_MATRIX = np.array([
+    [0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.0, 0.0, 0.0, 0.0, 0.0],
     [0.15580128, -0.07108746, 0.055198, -0.14199848, 0.0005317868],
     [-0.011208724, 0.21213274, -0.17233513, -0.4401193, 0.13930725],
     [0.12754257, -0.07938199, 0.083904505, -0.24103324, 0.0084449835],
@@ -93,6 +97,7 @@ DUMMY_ARGS_NO_PROCESSING = {'model_name': 'MT-LSTM-CRF',
                             'save_all_weights': 'False',
                             'tensorboard': 'False',
                             'replace_rare_tokens': 'False',
+                            'load_all_embeddings': 'False',
                             'fine_tune_word_embeddings': 'False',
                             # TEMP
                             'variational_dropout': 'False',
@@ -121,6 +126,7 @@ DUMMY_ARGS_NO_CLI_ARGS = {'model_name': 'mt-lstm-crf',
                           'save_all_weights': False,
                           'tensorboard': False,
                           'replace_rare_tokens': False,
+                          'load_all_embeddings': False,
                           'fine_tune_word_embeddings': False,
                           # TEMP
                           'variational_dropout': False,
@@ -159,8 +165,9 @@ DUMMY_ARGS_WITH_CLI_ARGS = {'model_name': 'mt-lstm-crf',
                             'debug': False,
                             'save_all_weights': False,
                             'tensorboard': False,
-                            'fine_tune_word_embeddings': False,
                             'replace_rare_tokens': False,
+                            'load_all_embeddings': False,
+                            'fine_tune_word_embeddings': False,
                             # TEMP
                             'variational_dropout': False,
                            }

--- a/saber/tests/resources/helpers.py
+++ b/saber/tests/resources/helpers.py
@@ -1,0 +1,60 @@
+"""Any and all helper functions for Sabers unit tests.
+"""
+import configparser
+import os
+
+from ... import constants
+
+
+def assert_type_to_idx_as_expected(actual, expected):
+    """Asserts that a `type_to_idx` mapping is as expected. This involves checking that it contains
+    the expected, keys, the expected values, and that the values are a consecutive mapping of
+    integers beginning at 0.
+    """
+    # check keys
+    assert all(word in actual['word'] for word in expected['word'])
+    assert all(char in actual['char'] for char in expected['char'])
+    # check that values are consectutive mapping of integers between 0 and length of the dictionary
+    assert all(id in range(0, len(actual['word'])) for id in actual['word'].values())
+    assert all(id in range(0, len(actual['char'])) for id in actual['char'].values())
+    # check initial mapping items
+    assert all(word in actual['word'] for word in constants.INITIAL_MAPPING['word'])
+    assert all(word in actual['char'] for word in constants.INITIAL_MAPPING['word'])
+
+def load_saved_config(filepath):
+    """Load a saved config.ConfigParser object at 'filepath/config.ini'.
+
+    Args:
+        filepath (str): filepath to the saved config file 'config.ini'
+
+    Returns:
+        parsed config.ConfigParser object at 'filepath/config.ini'.
+    """
+    saved_config_filepath = os.path.join(filepath, 'config.ini')
+    saved_config = configparser.ConfigParser()
+    saved_config.read(saved_config_filepath)
+
+    return saved_config
+
+def unprocess_args(args):
+    """Unprocesses processed config args.
+
+    Given a dictionary of arguments ('arg'), returns a dictionary where all values have been
+    converted to string representation.
+
+    Returns:
+        args, where all values have been replaced by a str representation.
+    """
+    unprocessed_args = {}
+    for arg, value in args.items():
+        if isinstance(value, list):
+            unprocessed_arg = ', '.join(value)
+        elif isinstance(value, dict):
+            dict_values = [str(v) for v in value.values()]
+            unprocessed_arg = ', '.join(dict_values)
+        else:
+            unprocessed_arg = str(value)
+
+        unprocessed_args[arg] = unprocessed_arg
+
+    return unprocessed_args

--- a/saber/tests/test_config.py
+++ b/saber/tests/test_config.py
@@ -1,11 +1,10 @@
 """Contains any and all unit tests for the config.Config class (saber/config.py).
 """
-import configparser
-
 import pytest
 
 from .. import config
 from .resources.dummy_constants import *
+from .resources.helpers import *
 
 ######################################### PYTEST FIXTURES #########################################
 
@@ -136,43 +135,3 @@ def test_save_with_cli_args(config_with_cli_args, tmpdir):
     for section in CONFIG_SECTIONS:
         for arg, value in saved_config[section].items():
             assert value == unprocessed_args[arg]
-
-######################################### HELPER FUNCTIONS #########################################
-
-def load_saved_config(filepath):
-    """Load a saved config.ConfigParser object at 'filepath/config.ini'.
-
-    Args:
-        filepath (str): filepath to the saved config file 'config.ini'
-
-    Returns:
-        parsed config.ConfigParser object at 'filepath/config.ini'.
-    """
-    saved_config_filepath = os.path.join(filepath, 'config.ini')
-    saved_config = configparser.ConfigParser()
-    saved_config.read(saved_config_filepath)
-
-    return saved_config
-
-def unprocess_args(args):
-    """Unprocesses processed config args.
-
-    Given a dictionary of arguments ('arg'), returns a dictionary where all values have been
-    converted to string representation.
-
-    Returns:
-        args, where all values have been replaced by a str representation.
-    """
-    unprocessed_args = {}
-    for arg, value in args.items():
-        if isinstance(value, list):
-            unprocessed_arg = ', '.join(value)
-        elif isinstance(value, dict):
-            dict_values = [str(v) for v in value.values()]
-            unprocessed_arg = ', '.join(dict_values)
-        else:
-            unprocessed_arg = str(value)
-
-        unprocessed_args[arg] = unprocessed_arg
-
-    return unprocessed_args

--- a/saber/tests/test_dataset.py
+++ b/saber/tests/test_dataset.py
@@ -90,10 +90,10 @@ def test_get_type_seq_single_dataset_before_load(empty_dummy_dataset):
 
 def test_get_idx_maps_single_dataset_before_load(empty_dummy_dataset):
     """Asserts that `Dataset.type_to_idx` is updated as expected after successive calls to
-    `Dataset._get_types()` and `Dataset.get_idx_maps()`.
+    `Dataset._get_types()` and `Dataset._get_idx_maps()`.
     """
     types = empty_dummy_dataset._get_types()
-    empty_dummy_dataset.get_idx_maps(types)
+    empty_dummy_dataset._get_idx_maps(types)
 
     # ensure that index mapping is a contigous sequence of numbers starting at 0
     assert generic_utils.is_consecutive(empty_dummy_dataset.type_to_idx['word'].values())
@@ -106,10 +106,10 @@ def test_get_idx_maps_single_dataset_before_load(empty_dummy_dataset):
 
 def test_get_idx_maps_single_dataset_before_load_special_tokens(empty_dummy_dataset):
     """Asserts that `Dataset.type_to_idx` contains the special tokens as keys with expected values
-     after successive calls to `Dataset._get_types()` and `Dataset.get_idx_maps()`.
+     after successive calls to `Dataset._get_types()` and `Dataset._get_idx_maps()`.
     """
     types = empty_dummy_dataset._get_types()
-    empty_dummy_dataset.get_idx_maps(types)
+    empty_dummy_dataset._get_idx_maps(types)
     # assert special tokens are mapped to the correct indices
     assert all(empty_dummy_dataset.type_to_idx['word'][k] == v for k, v in constants.INITIAL_MAPPING['word'].items())
     assert all(empty_dummy_dataset.type_to_idx['char'][k] == v for k, v in constants.INITIAL_MAPPING['word'].items())
@@ -117,11 +117,11 @@ def test_get_idx_maps_single_dataset_before_load_special_tokens(empty_dummy_data
 
 def test_get_idx_seq_single_dataset_before_load(empty_dummy_dataset):
     """Asserts that `Dataset.idx_seq` is updated as expected after successive calls to
-    `Dataset._get_type_seq()`, `Dataset.get_idx_maps()` and `Dataset.get_idx_seq()`.
+    `Dataset._get_type_seq()`, `Dataset._get_idx_maps()` and `Dataset.get_idx_seq()`.
     """
     types = empty_dummy_dataset._get_types()
     empty_dummy_dataset._get_type_seq()
-    empty_dummy_dataset.get_idx_maps(types)
+    empty_dummy_dataset._get_idx_maps(types)
     empty_dummy_dataset.get_idx_seq()
 
     # as a workaround to testing this directly, just check that shapes are as expected

--- a/saber/tests/test_embeddings.py
+++ b/saber/tests/test_embeddings.py
@@ -6,6 +6,7 @@ import pytest
 
 from ..embeddings import Embeddings
 from .resources.dummy_constants import *
+from .resources import helpers
 
 # TODO (johngiorgi): write tests using a binary format file
 # TODO (johngiorgi): write tests to test for debug functionality
@@ -14,15 +15,47 @@ from .resources.dummy_constants import *
 
 @pytest.fixture
 def dummy_embedding_idx():
-    """Returns embedding index from call to `._prepare_embedding_index()`.
+    """Returns embedding index from call to `Embeddings._prepare_embedding_index()`.
     """
     embeddings = Embeddings(filepath=PATH_TO_DUMMY_EMBEDDINGS, token_map=DUMMY_TOKEN_MAP)
     embedding_idx = embeddings._prepare_embedding_index(binary=False)
     return embedding_idx
 
 @pytest.fixture
+def dummy_embedding_matrix_and_type_to_idx():
+    """Returns the `embedding_matrix` and `type_to_index` objects from call to
+    `Embeddings._prepare_embedding_matrix(load_all=False)`.
+    """
+    embeddings = Embeddings(filepath=PATH_TO_DUMMY_EMBEDDINGS, token_map=DUMMY_TOKEN_MAP)
+    embedding_idx = embeddings._prepare_embedding_index(binary=False)
+    embeddings.num_found = len(embedding_idx)
+    embeddings.dimension = len(list(embedding_idx.values())[0])
+    embedding_matrix, type_to_idx = embeddings._prepare_embedding_matrix(embedding_idx, load_all=False)
+    embeddings.num_embed = embedding_matrix.shape[0] # num of embedded words
+
+    return embedding_matrix, type_to_idx
+
+@pytest.fixture
+def dummy_embedding_matrix_and_type_to_idx_load_all():
+    """Returns the embedding matrix and type to index objects from call to
+    `Embeddings._prepare_embedding_matrix(load_all=True)`.
+    """
+    # this should be different than DUMMY_TOKEN_MAP for a reliable test
+    test = {"This": 0, "is": 1, "a": 2, "test": 3}
+
+    embeddings = Embeddings(filepath=PATH_TO_DUMMY_EMBEDDINGS, token_map=test)
+    embedding_idx = embeddings._prepare_embedding_index(binary=False)
+    embeddings.num_found = len(embedding_idx)
+    embeddings.dimension = len(list(embedding_idx.values())[0])
+    embedding_matrix, type_to_idx = embeddings._prepare_embedding_matrix(embedding_idx, load_all=True)
+    embeddings.num_embed = embedding_matrix.shape[0] # num of embedded words
+
+    return embedding_matrix, type_to_idx
+
+@pytest.fixture
 def dummy_embeddings_before_load():
-    """Returns an instance of an Embeddings() object BEFORE the `.load()` method is called.
+    """Returns an instance of an Embeddings() object BEFORE the `Embeddings.load()` method is
+    called.
     """
     return Embeddings(filepath=PATH_TO_DUMMY_EMBEDDINGS,
                       token_map=DUMMY_TOKEN_MAP,
@@ -31,51 +64,137 @@ def dummy_embeddings_before_load():
 
 @pytest.fixture
 def dummy_embeddings_after_load():
-    """Returns an instance of an Embeddings() object AFTER the `.load()` method is called.
+    """Returns an instance of an Embeddings() object AFTER `Embeddings.load(load_all=False)` is
+    called.
     """
     embeddings = Embeddings(filepath=PATH_TO_DUMMY_EMBEDDINGS, token_map=DUMMY_TOKEN_MAP)
-    embeddings.load(binary=False) # txt file format is easier to test
+    embeddings.load(binary=False, load_all=False) # txt file format is easier to test
+    return embeddings
+
+@pytest.fixture
+def dummy_embeddings_after_load_with_load_all():
+    """Returns an instance of an Embeddings() object AFTER `Embeddings.load(load_all=True)` is
+    called.
+    """
+    # this should be different than DUMMY_TOKEN_MAP for a reliable test
+    test = {"This": 0, "is": 1, "a": 2, "test": 3}
+
+    embeddings = Embeddings(filepath=PATH_TO_DUMMY_EMBEDDINGS, token_map=test)
+    embeddings.load(binary=False, load_all=True) # txt file format is easier to test
     return embeddings
 
 ############################################ UNIT TESTS ############################################
 
 def test_initialization(dummy_embeddings_before_load):
-    """Asserts that Embeddings objects contain the expected attribute values after initialization.
+    """Asserts that Embeddings object contains the expected attribute values after initialization.
     """
     # test attributes whos values are passed to the constructor
     assert dummy_embeddings_before_load.filepath == PATH_TO_DUMMY_EMBEDDINGS
     assert dummy_embeddings_before_load.token_map == DUMMY_TOKEN_MAP
     # test attributes initialized with default values
     assert dummy_embeddings_before_load.matrix is None
-    assert dummy_embeddings_before_load.num_loaded is None
+    assert dummy_embeddings_before_load.num_found is None
+    assert dummy_embeddings_before_load.num_embed is None
     assert dummy_embeddings_before_load.dimension is None
     # test that we can pass arbitrary keyword arguments
     assert dummy_embeddings_before_load.totally_arbitrary == 'arbitrary'
 
 def test_prepare_embedding_index(dummy_embedding_idx):
-    """Asserts that we get the expected value back after call to `._prepare_embedding_index()`.
+    """Asserts that we get the expected value back after call to
+    `Embeddings._prepare_embedding_index()`.
     """
     # need to check keys and values differently
     assert dummy_embedding_idx.keys() == DUMMY_EMBEDDINGS_INDEX.keys()
     assert all(np.allclose(actual, expected) for actual, expected in
                zip(dummy_embedding_idx.values(), DUMMY_EMBEDDINGS_INDEX.values()))
 
-def test_prepare_embedding_matrix(dummy_embedding_idx, dummy_embeddings_after_load):
+def test_prepare_embedding_matrix(dummy_embedding_matrix_and_type_to_idx):
     """Asserts that we get the expected value back after successive calls to
-    `._prepare_embedding_index()` and `._prepare_embedding_matrix`.
+    `Embeddings._prepare_embedding_index()` and
+    `Embeddings._prepare_embedding_matrix(load_all=False)`.
     """
-    embedding_matrix = dummy_embeddings_after_load._prepare_embedding_matrix(dummy_embedding_idx)
-    assert np.allclose(embedding_matrix, DUMMY_EMBEDDINGS_MATRIX)
+    # expected_values
+    embedding_matrix_expected, type_to_idx_expected = DUMMY_EMBEDDINGS_MATRIX, None
+    # actual values
+    embedding_matrix_actual, type_to_idx_actual = dummy_embedding_matrix_and_type_to_idx
+
+    assert np.allclose(embedding_matrix_actual, embedding_matrix_expected)
+    assert type_to_idx_actual is type_to_idx_expected
+
+def test_prepare_embedding_matrix_load_all(dummy_embedding_matrix_and_type_to_idx_load_all):
+    """Asserts that we get the expected value back after successive calls to
+    `Embeddings._prepare_embedding_index()` and
+    `Embeddings._prepare_embedding_matrix(load_all=True)`.
+    """
+    # expected values
+    embedding_matrix_expected = DUMMY_EMBEDDINGS_MATRIX
+    type_to_idx_expected = {"word": DUMMY_TOKEN_MAP, "char": DUMMY_CHAR_MAP}
+    # actual values
+    embedding_matrix_actual, type_to_idx_actual = dummy_embedding_matrix_and_type_to_idx_load_all
+
+    assert np.allclose(embedding_matrix_actual, embedding_matrix_expected)
+    helpers.assert_type_to_idx_as_expected(actual=type_to_idx_actual, expected=type_to_idx_expected)
 
 def test_matrix_after_load(dummy_embeddings_after_load):
-    """Asserts that pre-trained token embeddings are loaded correctly when Embeddings.load() is
-    called."""
+    """Asserts that pre-trained token embeddings are loaded correctly when
+    `Embeddings.load(load_all=False)` is called."""
     assert np.allclose(dummy_embeddings_after_load.matrix, DUMMY_EMBEDDINGS_MATRIX)
 
-def test_attributes_after_load(dummy_embeddings_after_load):
-    """Asserts that attributes of Embeddings object are updated as expected after `.load()` is
-    called.
+def test_matrix_after_load_with_load_all(dummy_embeddings_after_load):
+    """Asserts that pre-trained token embeddings are loaded correctly when
+    `Embeddings.load(load_all=True)` is called."""
+    assert np.allclose(dummy_embeddings_after_load.matrix, DUMMY_EMBEDDINGS_MATRIX)
+
+def test_attributes_after_load(dummy_embedding_idx, dummy_embeddings_after_load):
+    """Asserts that attributes of Embeddings object are updated as expected after
+    `Embeddings.load(load_all=False)` is called.
     """
-    num_loaded, dimension = dummy_embeddings_after_load.matrix.shape
-    assert dummy_embeddings_after_load.num_loaded == num_loaded
-    assert dummy_embeddings_after_load.dimension == dimension
+    # expected values
+    num_found_expected = len(dummy_embedding_idx)
+    dimension_expected = len(list(dummy_embedding_idx.values())[0])
+    num_embed_expected = dummy_embeddings_after_load.matrix.shape[0]
+    # actual values
+    num_found_actual = dummy_embeddings_after_load.num_found
+    dimension_actual = dummy_embeddings_after_load.dimension
+    num_embed_actual = dummy_embeddings_after_load.num_embed
+
+    assert num_found_expected == num_found_actual
+    assert dimension_expected == dimension_actual
+    assert num_embed_expected == num_embed_actual
+
+def test_attributes_after_load_with_load_all(dummy_embedding_idx,
+                                             dummy_embeddings_after_load_with_load_all):
+    """Asserts that attributes of Embeddings object are updated as expected after
+    `Embeddings.load(load_all=True)` is called.
+    """
+    # expected values
+    num_found_expected = len(dummy_embedding_idx)
+    dimension_expected = len(list(dummy_embedding_idx.values())[0])
+    num_embed_expected = dummy_embeddings_after_load_with_load_all.matrix.shape[0]
+    # actual values
+    num_found_actual = dummy_embeddings_after_load_with_load_all.num_found
+    dimension_actual = dummy_embeddings_after_load_with_load_all.dimension
+    num_embed_actual = dummy_embeddings_after_load_with_load_all.num_embed
+
+    assert num_found_expected == num_found_actual
+    assert dimension_expected == dimension_actual
+    assert num_embed_expected == num_embed_actual
+
+def test_generate_type_to_idx(dummy_embeddings_before_load):
+    """Asserts that the dictionary returned from 'Embeddings._generate_type_to_idx()' is as
+    expected.
+    """
+    test = {'This': 0, 'is': 1, 'a': 2, 'test': 3}
+
+    # expected values
+    expected = {
+        "word": list(test.keys()),
+        "char": []
+    }
+    for word in expected['word']:
+        expected['char'].extend(list(word))
+    expected['char'] = list(set(expected['char']))
+    # actual values
+    actual = dummy_embeddings_before_load._generate_type_to_idx(test)
+
+    helpers.assert_type_to_idx_as_expected(actual=actual, expected=expected)

--- a/saber/utils/app_utils.py
+++ b/saber/utils/app_utils.py
@@ -144,6 +144,27 @@ def harmonize_entities(default_ents, requested_ents):
 
     return entities
 
+def parse_request_json(request):
+    """Returns a dictionary of data parsed from a JSON payload passed in a POST request to Saber.
+    """
+    request_json = request.get_json(force=True)
+    parsed_request_json = {
+        'text': request_json.get('text', None),
+        'pmid': request_json.get('pmid', None),
+        'ents': request_json.get('ents', None),
+        'coref': request_json.get('coref', False),
+        'ground': request_json.get('ground', False),
+    }
+
+    # decide which entities to annotate
+    default_ents, requested_ents = constants.ENTITIES, parsed_request_json['ents']
+    if requested_ents is not None:
+        parsed_request_json['ents'] = harmonize_entities(default_ents, requested_ents)
+    else:
+        parsed_request_json['ents'] = default_ents
+
+    return parsed_request_json
+
 def combine_annotations(annotations):
     """Given a list of annotations made by a Saber model, combines all annotations under one dict.
 

--- a/saber/utils/data_utils.py
+++ b/saber/utils/data_utils.py
@@ -109,8 +109,9 @@ def load_compound_dataset(config):
     }
     for dataset in compound_dataset:
         # 3. update each datasets type_to_idx mappings (for word and char types only)
-        dataset.type_to_idx['word'].update(type_to_idx['word'])
-        dataset.type_to_idx['char'].update(type_to_idx['char'])
+        word_types, char_types = list(dataset.type_to_idx['word']), list(dataset.type_to_idx['char'])
+        dataset.type_to_idx['word'] = Preprocessor.type_to_idx(word_types, type_to_idx['word'])
+        dataset.type_to_idx['char'] = Preprocessor.type_to_idx(char_types, type_to_idx['char'])
         # 4. re-compute the index sequences
         dataset.get_idx_seq()
 

--- a/saber/utils/grounding_utils.py
+++ b/saber/utils/grounding_utils.py
@@ -4,6 +4,8 @@ import logging
 
 import requests
 
+from ..preprocessor import Preprocessor
+
 LOGGER = logging.getLogger(__name__)
 
 def _query_uniprot(text, organisms=('9606'), limit=1):
@@ -59,7 +61,8 @@ def _query_uniprot(text, organisms=('9606'), limit=1):
         if response.status_code == 200:
             lines = response.text.splitlines()
             if len(lines) > 1:
-                col_names = lines[0].split('\t')
+                # text returned by uniprot api has weird spacing, so clean it
+                col_names = [Preprocessor.sterilize(line) for line in lines[0].split('\t')]
             for line in lines[1:]:
                 col_vals = line.split('\t')
                 xref = dict(zip(col_names, col_vals))


### PR DESCRIPTION
This pull request addresses #92. A user now has the option to load _all_ pre-trained embeddings, and not just those that appear in the training set. This is useful for deployment and transfer learning (as outlined in the issue).

This functionality is "off" by default and enabled with the `load_all_embeddings` argument (at the command line or in the config file) __or__ via the `load_all` argument in a call to `Saber.load_embeddings()`.

Closes #92.