### PR TITLE
Fixes build issue on TravisCI caused by msgpack issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ install:
   - pip install coveralls
   # TEMP: fixes weird issue caused by Gensim
   - pip install google-compute-engine
+  # TEMP: fixes weird issue caused by msgpack
+  - pip install msgpack==0.5.6
 
 script:
   - pytest --cov=saber -v


### PR DESCRIPTION
Builds on TravisCI were breaking for reasons I don't understand (the error message was very cryptic). Seems to be a problem with `msgpack` which is a dependency of SpaCy. The [solution](https://github.com/RasaHQ/rasa_nlu/issues/1563) was to downgrade `msgpack` in the build.