### PR TITLE
Add grounding for major entity types using EXTRACT 2.0 API

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The goal is that Saber will eventually perform all the important steps in text-m
 
 - Coreference resolution (:white_check_mark:)
 - Biomedical named entity recognition (BioNER) (:white_check_mark:)
-- Entity linking / grounding / normalization (:soon:)
+- Entity linking / grounding / normalization (:white_check_mark:)
 - Simple relation extraction (:soon:)
 - Event extraction (:soon:)
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -87,7 +87,7 @@ saber.load('PRGE')
 ```
 
 !!! tip
-    See [Resources: Pre-trained models](https://baderlab.github.io/saber/resources/#pre-trained-models) for pre-trained model names and details. You will need an internet connection to download a pre-trained model.
+    See [Resources: Pre-trained models](../resources#pre-trained-models) for pre-trained model names and details. You will need an internet connection to download a pre-trained model.
 
 To annotate text with the model, just call the `Saber.annotate()` method
 
@@ -118,6 +118,21 @@ saber.annotate(text, coref=True)
     If you are using the web-service, simply supply `"coref": true` in your `JSON` payload to resolve coreferences.
 
 Saber currently takes the simplest possible approach: replace all coreference mentions with their referent, and then feed the resolved text to the model that identifies named entities.
+
+### Grounding
+
+**Grounding** (sometimes called **entity linking** or **normalization**) involves mapping each annotated entity to a unique identifier in an external resource such as a database or ontology. To ground entities in a call to `Saber.annotate()`, simply pass the argument `ground=True`
+
+```python
+saber.annotate('The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.', ground=True)
+```
+
+The grounding functionality is implemented by the [EXTRACT 2.0 API](https://extract.jensenlab.org/). Note that you will need an internet connection or grounding will fail. Also note that `Saber.annotate()` will take slightly longer to return a response when `ground=True` (up to a few seconds).
+
+See [Resources: Pre-trained models](../resources#pre-trained-models) for a list of the the external resources each entity type (annotated by the pre-trained models) is grounded to.
+
+!!! note
+    If you are using the web-service, simply supply `"ground": true` in your `JSON` payload to ground entities.
 
 ### Working with annotations
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -6,12 +6,12 @@ Saber is ready to go out-of-the box when using the __web-service__ or a __pre-tr
 
 Pre-trained model names can be passed to `Saber.load()` (see [Quick Start: Pre-trained Models](https://baderlab.github.io/saber/quick_start/#pre-trained-models)). Appending `"*-large"` to the model name (e.g. `"PRGE-large"` will download a much larger model, which should perform slightly better than the base model.
 
-Identifier | Semantic Group | Identified entity types
----------- | -------------- | -----------------------
-`CHED` | Chemicals | Abbreviations and Acronyms, Molecular Formulas, Chemical database identifiers, IUPAC names, Trivial (common names of chemicals and trademark names), Family (chemical families with a defined structure) and Multiple (non-continuous mentions of chemicals in text)
-`DISO` | Disorders | Acquired Abnormality, Anatomical Abnormality, Cell or Molecular Dysfunction, Congenital Abnormality, Disease or Syndrome, Mental or Behavioral Dysfunction, Neoplastic Process, Pathologic Function, Sign or Symptom
-`LIVB` | Organisms | Species, Taxa
-`PRGE` | Genes and Gene Products | Genes, Gene Products
+Identifier | Semantic Group | Identified entity types | Namespace |
+---------- | -------------- | ----------------------- | --------- |
+`CHED` | Chemicals | Abbreviations and Acronyms, Molecular Formulas, Chemical database identifiers, IUPAC names, Trivial (common names of chemicals and trademark names), Family (chemical families with a defined structure) and Multiple (non-continuous mentions of chemicals in text) | [PubChem Compounds](https://pubchem.ncbi.nlm.nih.gov/)
+`DISO` | Disorders | Acquired Abnormality, Anatomical Abnormality, Cell or Molecular Dysfunction, Congenital Abnormality, Disease or Syndrome, Mental or Behavioral Dysfunction, Neoplastic Process, Pathologic Function, Sign or Symptom | [Disease Ontology](http://disease-ontology.org/)
+`LIVB` | Organisms | Species, Taxa | [NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/taxonomy)
+`PRGE` | Genes and Gene Products | Genes, Gene Products | [STRING](https://string-db.org/)
 
 ## Datasets
 

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -37,7 +37,7 @@ VALID_FILE = 'valid.*'
 TEST_FILE = 'test.*'
 # pre-trained models
 ENTITIES = {'ANAT': False,
-            'CHED': False,
+            'CHED': True,
             'DISO': True,
             'LIVB': False,
             'PRGE': True,

--- a/saber/constants.py
+++ b/saber/constants.py
@@ -69,6 +69,16 @@ UNITS_DENSE = UNITS_WORD_LSTM // 2
 # possible models
 MODEL_NAMES = ['mt-lstm-crf',]
 
+# EXTRACT 2.0 API
+# arguments passed in a get request to the EXTRACT 2.0 API to specify entity type
+ENTITY_TYPES = {'CHED': -1, 'DISO': -26, 'LIVB': -2}
+# the namespaces of the external resources that EXTRACT 2.0 grounds too
+NAMESPACES = {'CHED': 'PubChem Compound',
+              'DISO': 'Disease Ontology',
+              'LIVB': 'NCBI Taxonomy',
+              'PRGE': 'STRING',
+              }
+
 # RESTful API
 # endpoint for Entrez Utilities Web Service API
 EUTILS_API_ENDPOINT = ('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?retmode=xml&db='

--- a/saber/preprocessor.py
+++ b/saber/preprocessor.py
@@ -6,10 +6,9 @@ import logging
 import re
 from collections import Counter
 
+import en_coref_md
 import numpy as np
 from keras.preprocessing.sequence import pad_sequences
-
-import en_coref_md
 
 from . import constants
 from .utils import generic_utils, text_utils

--- a/saber/saber.py
+++ b/saber/saber.py
@@ -7,10 +7,10 @@ import time
 from itertools import chain
 from pprint import pprint
 
+from google_drive_downloader import GoogleDriveDownloader as gdd
 from spacy import displacy
 
 from . import constants
-from google_drive_downloader import GoogleDriveDownloader as gdd
 from .config import Config
 from .dataset import Dataset
 from .embeddings import Embeddings
@@ -74,7 +74,11 @@ class Saber(object):
         """
         # this takes about a minute to load, so only do it once!
         if self.preprocessor is None:
+            start = time.time()
+            print('Loading preprocessor... (note this only happens once)', end=' ', flush=True)
             self.preprocessor = Preprocessor()
+            end = time.time() - start
+            print('Done ({0:.2f} seconds).'.format(end))
 
         if not isinstance(text, str) or not text:
             err_msg = "Argument `text` must be a valid, non-empty string."

--- a/saber/saber.py
+++ b/saber/saber.py
@@ -49,7 +49,7 @@ class Saber(object):
             pprint({arg: getattr(self.config, arg) for arg in constants.CONFIG_ARGS})
             os.environ['TF_CPP_MIN_LOG_LEVEL'] = '0'
 
-    def annotate(self, text, model_idx=0, jupyter=False, coref=False, ground=False):
+    def annotate(self, text, title='', model_idx=0, jupyter=False, coref=False, ground=False):
         """Uses a trained model (`self.model`) to annotate `text`, returns a dictionary.
 
         For the model at `self.model.models[model_idx]`, coordinates a prediction step on `text`.
@@ -75,7 +75,7 @@ class Saber(object):
         # this takes about a minute to load, so only do it once!
         if self.preprocessor is None:
             start = time.time()
-            print('Loading preprocessor... (note this only happens once)', end=' ', flush=True)
+            print('Loading preprocessor...', end=' ', flush=True)
             self.preprocessor = Preprocessor()
             end = time.time() - start
             print('Done ({0:.2f} seconds).'.format(end))
@@ -111,10 +111,15 @@ class Saber(object):
             text = transformed_text['text'][start:end]
             ents.append({'start': start, 'end': end, 'text': text, 'label': label})
 
-        # create the final annotation and ground it
-        annotation = {'text': transformed_text['text'], 'ents': ents}
+        annotation = {'text': transformed_text['text'], 'title': title, 'ents': ents}
+
         if ground:
-            annotation = grounding_utils.ground(annotation)
+            try:
+                annotation = grounding_utils.ground(annotation)
+            except:
+                err_msg = ("Grounding step in `Saber.annotate()` failed (`grounding_utils.ground()`"
+                           " threw an error. Check that you have a stable internet connection.")
+                LOGGER.error(err_msg)
 
         if jupyter:
             displacy.render(annotation, jupyter=True, style='ent', manual=True,

--- a/saber/tests/test_data_utils.py
+++ b/saber/tests/test_data_utils.py
@@ -1,7 +1,6 @@
 """Any and all unit tests for the data_utils (saber/utils/data_utils.py).
 """
 import numpy as np
-
 import pytest
 
 from ..config import Config

--- a/saber/tests/test_dataset.py
+++ b/saber/tests/test_dataset.py
@@ -3,9 +3,8 @@
 import os
 
 import numpy as np
-from nltk.corpus.reader.conll import ConllCorpusReader
-
 import pytest
+from nltk.corpus.reader.conll import ConllCorpusReader
 
 from .. import constants
 from ..dataset import Dataset

--- a/saber/tests/test_embeddings.py
+++ b/saber/tests/test_embeddings.py
@@ -1,12 +1,11 @@
 """Any and all unit tests for the Embeddings class (saber/embeddings.py).
 """
 import numpy as np
-
 import pytest
 
 from ..embeddings import Embeddings
-from .resources.dummy_constants import *
 from .resources import helpers
+from .resources.dummy_constants import *
 
 # TODO (johngiorgi): write tests using a binary format file
 # TODO (johngiorgi): write tests to test for debug functionality

--- a/saber/tests/test_grounding_utils.py
+++ b/saber/tests/test_grounding_utils.py
@@ -5,53 +5,83 @@ import pytest
 from ..utils import grounding_utils
 
 @pytest.fixture
-def ched_annotation():
+def blank_annotation():
+    """Returns an annotation with no identified entities.
     """
-    """
-    annotation = {"ents": [{"text": "glucose", "label": "CHED", "start": 0, "end": 6}],
-                  "text": "glucose",
+    annotation = {"ents": [],
+                  "text": "This is a test with no entities.",
                   "title": ""}
+    return annotation
+
+@pytest.fixture
+def ched_annotation():
+    """Returns an annotation with chemical entities (CHED) identified.
+    """
+    annotation = {"ents": [{"text": "glucose", "label": "CHED", "start": 0, "end": 0},
+                           {"text": "fructose", "label": "CHED", "start": 0, "end": 0}],
+                  "text": "glucose and fructose",
+                  "title": ""}
+
     return annotation
 
 @pytest.fixture
 def diso_annotation():
+    """Returns an annotation with disease entities (DISO) identified.
     """
-    """
-    annotation = {"ents": [{"text": "cancer", "label": "DISO", "start": 0, "end": 5}],
-                  "text": "cancer",
+    annotation = {"ents": [{"text": "cancer", "label": "DISO", "start": 0, "end": 0},
+                           {"text": "cystic fibrosis", "label": "DISO", "start": 0, "end": 0}],
+                  "text": "cancer and cystic fibrosis",
                   "title": ""}
+
     return annotation
 
 @pytest.fixture
 def livb_annotation():
+    """Returns an annotation with species entities (LIVB) identified.
     """
-    """
-    annotation = {"ents": [{"text": "mouse", "label": "LIVB", "start": 0, "end": 4}],
-                  "text": "mouse",
+    annotation = {"ents": [{"text": "mouse", "label": "LIVB", "start": 0, "end": 0},
+                           {"text": "human", "label": "LIVB", "start": 0, "end": 0}],
+                  "text": "mouse and human",
                   "title": ""}
+
     return annotation
 
 @pytest.fixture
 def prge_annotation():
+    """Returns an annotation with protein/gene entities (PRGE) identified.
     """
-    """
-    annotation = {"ents": [{"text": "p53", "label": "PRGE", "start": 0, "end": 3}],
-                  "text": "p53",
+    annotation = {"ents": [{"text": "p53", "label": "PRGE", "start": 0, "end": 0},
+                           {"text": "MK2", "label": "PRGE", "start": 0, "end": 0}],
+                  "text": "p53 and MK2",
                   "title": ""}
+
     return annotation
+
+def test_ground_no_entites(blank_annotation):
+    """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
+    no identified entities.
+    """
+
+    actual = grounding_utils.ground(blank_annotation)
+    expected = blank_annotation
+
+    assert actual == expected
 
 def test_ground_chemicals(ched_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     chemical entities.
     """
-    xrefs = [
+    glucose_xrefs = [
         {'namespace': 'TODO', 'id': 'CIDs00005793'},
         {'namespace': 'TODO', 'id': 'CIDs10954115'},
         {'namespace': 'TODO', 'id': 'CIDs53782692'},
     ]
+    fructose_xrefs = [{'namespace': 'TODO', 'id': 'CIDs00439709'}]
+
+    ched_annotation['ents'][0].update(xrefs=glucose_xrefs)
+    ched_annotation['ents'][1].update(xrefs=fructose_xrefs)
 
     actual = grounding_utils.ground(ched_annotation)
-    ched_annotation['ents'][0].update(xrefs=xrefs)
     expected = ched_annotation
 
     assert actual == expected
@@ -60,12 +90,13 @@ def test_ground_diso(diso_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     disease entities.
     """
-    xrefs = [
-        {'namespace': 'TODO', 'id': 'DOID:162'},
-    ]
+    cancer_xrefs = [{'namespace': 'TODO', 'id': 'DOID:162'}]
+    cystic_fibrosis_xrefs = [{'namespace': 'TODO', 'id': 'DOID:1485'}]
+
+    diso_annotation['ents'][0].update(xrefs=cancer_xrefs)
+    diso_annotation['ents'][1].update(xrefs=cystic_fibrosis_xrefs)
 
     actual = grounding_utils.ground(diso_annotation)
-    diso_annotation['ents'][0].update(xrefs=xrefs)
     expected = diso_annotation
 
     assert actual == expected
@@ -74,13 +105,16 @@ def test_ground_livb(livb_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     species entities.
     """
-    xrefs = [
+    mouse_xrefs = [
         {'namespace': 'TODO', 'id': '10090'},
         {'namespace': 'TODO', 'id': '10088'},
     ]
+    human_xrefs = [{'namespace': 'TODO', 'id': '9606'}]
+
+    livb_annotation['ents'][0].update(xrefs=mouse_xrefs)
+    livb_annotation['ents'][1].update(xrefs=human_xrefs)
 
     actual = grounding_utils.ground(livb_annotation)
-    livb_annotation['ents'][0].update(xrefs=xrefs)
     expected = livb_annotation
 
     assert actual == expected
@@ -89,13 +123,16 @@ def test_ground_prge(prge_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     species entities.
     """
-    xrefs = [
-        {'namespace': 'TODO', 'id': 'ENSP00000269305', 'organism-id': '9606'},
-        {'namespace': 'TODO', 'id': '10088'},
+    p53_xrefs = [{'namespace': 'TODO', 'id': 'ENSP00000269305', 'organism-id': '9606'}]
+    mk2_xrefs = [
+        {'namespace': 'TODO', 'id': 'ENSP00000356070', 'organism-id': '9606'},
+        {'namespace': 'TODO', 'id': 'ENSP00000433109', 'organism-id': '9606'},
     ]
 
+    prge_annotation['ents'][0].update(xrefs=p53_xrefs)
+    prge_annotation['ents'][1].update(xrefs=mk2_xrefs)
+
     actual = grounding_utils.ground(prge_annotation)
-    prge_annotation['ents'][0].update(xrefs=xrefs)
     expected = prge_annotation
 
     assert actual == expected

--- a/saber/tests/test_grounding_utils.py
+++ b/saber/tests/test_grounding_utils.py
@@ -4,43 +4,98 @@ import pytest
 
 from ..utils import grounding_utils
 
-
 @pytest.fixture
-def annotation():
-    """Returns a dictionary object similar to one that might be returned by `Saber.annotate()`
+def ched_annotation():
     """
-    annotation = {"ents": [{"text": "Hdm2", "label": "PRGE", "start": 23, "end": 27},
-                           {"text": "MK2", "label": "PRGE", "start": 31, "end": 34},
-                           {"text": "p53", "label": "PRGE", "start": 66, "end": 69}
-                          ],
-                  "text": "The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.",
+    """
+    annotation = {"ents": [{"text": "glucose", "label": "CHED", "start": 0, "end": 6}],
+                  "text": "glucose",
                   "title": ""}
-
     return annotation
 
-def test_query_uniprot(annotation):
+@pytest.fixture
+def diso_annotation():
     """
     """
-    text = annotation['ents'][1]['text']
-    actual = grounding_utils._query_uniprot(text, 9606, limit=1)
-    assert len(actual) == 1
-    assert actual[0]['Entry'] == 'P49137'
-    assert len(actual[0].keys()) == 3
-    #short text
-    actual = grounding_utils._query_uniprot("p")
-    assert actual == []
+    annotation = {"ents": [{"text": "cancer", "label": "DISO", "start": 0, "end": 5}],
+                  "text": "cancer",
+                  "title": ""}
+    return annotation
 
-def test_ground(annotation):
+@pytest.fixture
+def livb_annotation():
     """
     """
-    actual = grounding_utils.ground(annotation, ('human', 'mouse'), limit=2)
-    assert actual is not None
-    for ent in actual['ents']:
-        assert 'xrefs' in ent.keys()
+    annotation = {"ents": [{"text": "mouse", "label": "LIVB", "start": 0, "end": 4}],
+                  "text": "mouse",
+                  "title": ""}
+    return annotation
 
-def test_query_hgnc(annotation):
+@pytest.fixture
+def prge_annotation():
     """
     """
-    actual = grounding_utils._query_hgnc(annotation)
-    assert actual is None
-    #TODO: implement _query_hgnc, make test fail, then fix
+    annotation = {"ents": [{"text": "p53", "label": "PRGE", "start": 0, "end": 3}],
+                  "text": "p53",
+                  "title": ""}
+    return annotation
+
+def test_ground_chemicals(ched_annotation):
+    """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
+    chemical entities.
+    """
+    xrefs = [
+        {'namespace': 'TODO', 'id': 'CIDs00005793'},
+        {'namespace': 'TODO', 'id': 'CIDs10954115'},
+        {'namespace': 'TODO', 'id': 'CIDs53782692'},
+    ]
+
+    actual = grounding_utils.ground(ched_annotation)
+    ched_annotation['ents'][0].update(xrefs=xrefs)
+    expected = ched_annotation
+
+    assert actual == expected
+
+def test_ground_diso(diso_annotation):
+    """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
+    disease entities.
+    """
+    xrefs = [
+        {'namespace': 'TODO', 'id': 'DOID:162'},
+    ]
+
+    actual = grounding_utils.ground(diso_annotation)
+    diso_annotation['ents'][0].update(xrefs=xrefs)
+    expected = diso_annotation
+
+    assert actual == expected
+
+def test_ground_livb(livb_annotation):
+    """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
+    species entities.
+    """
+    xrefs = [
+        {'namespace': 'TODO', 'id': '10090'},
+        {'namespace': 'TODO', 'id': '10088'},
+    ]
+
+    actual = grounding_utils.ground(livb_annotation)
+    livb_annotation['ents'][0].update(xrefs=xrefs)
+    expected = livb_annotation
+
+    assert actual == expected
+
+def test_ground_prge(prge_annotation):
+    """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
+    species entities.
+    """
+    xrefs = [
+        {'namespace': 'TODO', 'id': 'ENSP00000269305', 'organism-id': '9606'},
+        {'namespace': 'TODO', 'id': '10088'},
+    ]
+
+    actual = grounding_utils.ground(prge_annotation)
+    prge_annotation['ents'][0].update(xrefs=xrefs)
+    expected = prge_annotation
+
+    assert actual == expected

--- a/saber/tests/test_grounding_utils.py
+++ b/saber/tests/test_grounding_utils.py
@@ -1,8 +1,12 @@
 """Any and all unit tests for the grounding_utils (saber/utils/grounding_utils.py).
 """
+import copy
+
 import pytest
 
+from .. import constants
 from ..utils import grounding_utils
+
 
 @pytest.fixture
 def blank_annotation():
@@ -71,17 +75,19 @@ def test_ground_chemicals(ched_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     chemical entities.
     """
+    actual = grounding_utils.ground(copy.deepcopy(ched_annotation))
+
+    # create expected value
     glucose_xrefs = [
-        {'namespace': 'TODO', 'id': 'CIDs00005793'},
-        {'namespace': 'TODO', 'id': 'CIDs10954115'},
-        {'namespace': 'TODO', 'id': 'CIDs53782692'},
+        {'namespace': constants.NAMESPACES['CHED'], 'id': 'CIDs00005793'},
+        {'namespace': constants.NAMESPACES['CHED'], 'id': 'CIDs10954115'},
+        {'namespace': constants.NAMESPACES['CHED'], 'id': 'CIDs53782692'},
     ]
-    fructose_xrefs = [{'namespace': 'TODO', 'id': 'CIDs00439709'}]
+    fructose_xrefs = [{'namespace': constants.NAMESPACES['CHED'], 'id': 'CIDs00439709'}]
 
     ched_annotation['ents'][0].update(xrefs=glucose_xrefs)
     ched_annotation['ents'][1].update(xrefs=fructose_xrefs)
 
-    actual = grounding_utils.ground(ched_annotation)
     expected = ched_annotation
 
     assert actual == expected
@@ -90,13 +96,15 @@ def test_ground_diso(diso_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     disease entities.
     """
-    cancer_xrefs = [{'namespace': 'TODO', 'id': 'DOID:162'}]
-    cystic_fibrosis_xrefs = [{'namespace': 'TODO', 'id': 'DOID:1485'}]
+    actual = grounding_utils.ground(copy.deepcopy(diso_annotation))
+
+    # create expected value
+    cancer_xrefs = [{'namespace': constants.NAMESPACES['DISO'], 'id': 'DOID:162'}]
+    cystic_fibrosis_xrefs = [{'namespace': constants.NAMESPACES['DISO'], 'id': 'DOID:1485'}]
 
     diso_annotation['ents'][0].update(xrefs=cancer_xrefs)
     diso_annotation['ents'][1].update(xrefs=cystic_fibrosis_xrefs)
 
-    actual = grounding_utils.ground(diso_annotation)
     expected = diso_annotation
 
     assert actual == expected
@@ -105,16 +113,18 @@ def test_ground_livb(livb_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     species entities.
     """
+    actual = grounding_utils.ground(copy.deepcopy(livb_annotation))
+
+    # create expected value
     mouse_xrefs = [
-        {'namespace': 'TODO', 'id': '10090'},
-        {'namespace': 'TODO', 'id': '10088'},
+        {'namespace': constants.NAMESPACES['LIVB'], 'id': '10090'},
+        {'namespace': constants.NAMESPACES['LIVB'], 'id': '10088'},
     ]
-    human_xrefs = [{'namespace': 'TODO', 'id': '9606'}]
+    human_xrefs = [{'namespace': constants.NAMESPACES['LIVB'], 'id': '9606'}]
 
     livb_annotation['ents'][0].update(xrefs=mouse_xrefs)
     livb_annotation['ents'][1].update(xrefs=human_xrefs)
 
-    actual = grounding_utils.ground(livb_annotation)
     expected = livb_annotation
 
     assert actual == expected
@@ -123,16 +133,20 @@ def test_ground_prge(prge_annotation):
     """Asserts that `grounding_utils.ground()` returns the expected value for a simple example with
     species entities.
     """
-    p53_xrefs = [{'namespace': 'TODO', 'id': 'ENSP00000269305', 'organism-id': '9606'}]
+    actual = grounding_utils.ground(copy.deepcopy(prge_annotation))
+
+    # create expected value
+    p53_xrefs = [
+        {'namespace': constants.NAMESPACES['PRGE'], 'id': 'ENSP00000269305', 'organism-id': '9606'}
+    ]
     mk2_xrefs = [
-        {'namespace': 'TODO', 'id': 'ENSP00000356070', 'organism-id': '9606'},
-        {'namespace': 'TODO', 'id': 'ENSP00000433109', 'organism-id': '9606'},
+        {'namespace': constants.NAMESPACES['PRGE'], 'id': 'ENSP00000356070', 'organism-id': '9606'},
+        {'namespace': constants.NAMESPACES['PRGE'], 'id': 'ENSP00000433109', 'organism-id': '9606'},
     ]
 
     prge_annotation['ents'][0].update(xrefs=p53_xrefs)
     prge_annotation['ents'][1].update(xrefs=mk2_xrefs)
 
-    actual = grounding_utils.ground(prge_annotation)
     expected = prge_annotation
 
     assert actual == expected

--- a/saber/tests/test_model_utils.py
+++ b/saber/tests/test_model_utils.py
@@ -2,9 +2,8 @@
 """
 import os
 
-from keras.callbacks import ModelCheckpoint, TensorBoard
-
 import pytest
+from keras.callbacks import ModelCheckpoint, TensorBoard
 
 from ..config import Config
 from ..utils import model_utils

--- a/saber/tests/test_multi_task_lstm_crf.py
+++ b/saber/tests/test_multi_task_lstm_crf.py
@@ -1,8 +1,7 @@
 """Any and all unit tests for the MultiTaskLSTMCRF (saber/models/multi_task_lstm_crf.py).
 """
-from keras.engine.training import Model
-
 import pytest
+from keras.engine.training import Model
 
 from ..config import Config
 from ..dataset import Dataset

--- a/saber/tests/test_saber.py
+++ b/saber/tests/test_saber.py
@@ -8,8 +8,8 @@ from ..embeddings import Embeddings
 from ..models.base_model import BaseKerasModel
 from ..preprocessor import Preprocessor
 from ..saber import MissingStepException, Saber
-from .resources.dummy_constants import *
 from .resources import helpers
+from .resources.dummy_constants import *
 
 # TODO (johngiorgi): Write tests for compound dataset
 

--- a/saber/tests/test_saber.py
+++ b/saber/tests/test_saber.py
@@ -246,7 +246,7 @@ def test_annotate_single(saber_single_dataset_model):
     """Asserts that call to `Saber.annotate()` returns the expected results with a single dataset
     loaded."""
     test = "This is a simple test. With multiple sentences"
-    expected = {'text': test, 'ents': []}
+    expected = {'text': test, 'title': '', 'ents': []}
 
     actual = saber_single_dataset_model.annotate(test)
     actual['ents'] = [] # wipe the predicted ents as they are stochastic.

--- a/saber/utils/app_utils.py
+++ b/saber/utils/app_utils.py
@@ -104,11 +104,9 @@ def load_models(ents):
     models = {} # acc for models
     for ent, value in ents.items():
         if value:
-            path_to_model = os.path.join(constants.PRETRAINED_MODEL_DIR, '{}'.format(ent))
-            generic_utils.extract_directory(path_to_model)
             # create and load the pre-trained models
             saber = Saber()
-            saber.load(path_to_model)
+            saber.load(ent)
             models[ent] = saber
     # TEMP: Weird solution to a weird bug.
     # https://github.com/tensorflow/tensorflow/issues/14356#issuecomment-385962623

--- a/saber/utils/grounding_utils.py
+++ b/saber/utils/grounding_utils.py
@@ -4,6 +4,7 @@ import logging
 
 import requests
 
+from .. import constants
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,15 +34,13 @@ def ground(annotation):
         'LIVB': [ent for ent in annotation['ents'] if ent['label'] == 'LIVB'],
         'PRGE': [ent for ent in annotation['ents'] if ent['label'] == 'PRGE'],
     }
-    # mapping of labels to entity_types argument required by EXTRACT 2.0 API
-    entity_types = {'CHED': -1, 'DISO': -26, 'LIVB': -2}
 
     for label, anns in annotations.items():
         if anns:
             # prepand to GET request the text to ground along with its entity type
             current_request = '{}{}'.format(request, '+'.join([ann['text'] for ann in anns]))
-            if label in entity_types:
-                current_request += '&entity_types={}'.format(entity_types[label])
+            if label in constants.ENTITY_TYPES:
+                current_request += '&entity_types={}'.format(constants.ENTITY_TYPES[label])
 
             # request to EXTRACT 2.0 API
             response = requests.get(current_request).text
@@ -51,8 +50,8 @@ def ground(annotation):
 
             # collect unique identifiers returned by EXTRACT 2.0 API
             for entry in entries:
-                xref = {'namespace': 'TODO', 'id': entry[-1]}
-                # in the future, EXTRACT 2.0 API will to assign organim-ids to PRGE labels
+                xref = {'namespace': constants.NAMESPACES[label], 'id': entry[-1]}
+                # in the future, EXTRACT 2.0 API will to assign organism-ids to PRGE labels
                 if label == 'PRGE':
                     xref['organism-id'] = entry[1]
 

--- a/saber/utils/grounding_utils.py
+++ b/saber/utils/grounding_utils.py
@@ -4,87 +4,57 @@ import logging
 
 import requests
 
-from ..preprocessor import Preprocessor
 
 LOGGER = logging.getLogger(__name__)
 
-def _query_uniprot(text, organisms=('9606'), limit=1):
-    """Query for accession numbers using UniProt REST api
-    Example:
-      https://www.uniprot.org/uniprot/?query=name:mk2&columns=id&format=tab
-    See:
-      https://www.uniprot.org/help/api_queries
-      https://www.uniprot.org/help/query-fields
-      https://www.uniprot.org/help/uniprotkb_column_names
-      https://www.uniprot.org/help/programmatic_access
+def ground(annotation):
+    """Maps entities in `annotation` to unique indentifiers in an external database or ontology.
 
-     Args:
-        text: Gene or gene product name, synonym, or id.
-        organisms: Names or taxonomy ids; can be number, string or tuple.
-        limit: Max number of hits (result rows ordered by relevance).
+    For each entry in `annotation[ents]`, the text representing the annotation (`ent['text']`) is
+    mapped to a unique identifier in an external database or ontology (if such a unique identifier
+    is found). Each annotation in `annotation` is updated with an 'xrefs' key which contains a
+    dictionary with information representing the mapping.
 
-    Returns:
-        xrefs, a list of dictionaries [{'col1':'val1', 'col2':'val2',..},..]
+    This function relies on the EXTRACT API to perform the mapping.
+
+    Args:
+        annotation (dict): A dict containing a list of annotations at key 'ents'. Each annotation
+            is expected to have a key 'text'.
+
+    Resources:
+        - EXTRACT 2.0 API: https://extract.jensenlab.org/
     """
-    if len(text) < 2:
-        logging.error('query text must be at least two characters long')
-        return []
+    request = 'https://tagger.jensenlab.org/GetEntities?format=tsv&document='
 
-    xrefs = []
-    # fields, columns can be parameters too if we'd generalize later
-    fields = ('name', 'gene_exact', 'mnemonic')
-    columns = ('id', 'organism-id', 'genes(PREFERRED)')
-    params = {"sort": "score", "format": "tab"}
-
-    query = text
-    if fields is not None:
-        query = " OR ".join([f + ':' + str(text) for f in fields])
-    # filter by organism
-    if organisms is not None:
-        if isinstance(organisms, (int, str)):
-            subquery = "organism:" + str(organisms)
-        else:
-            subquery = " OR ".join(['organism:'+str(o) for o in organisms])
-        query = "({query}) AND ({subquery})".format(query=query, subquery=subquery)
-    params.update(query=query)
-
-    # set output data columns
-    if columns is not None:
-        params.update(columns=",".join(columns))
-
-    # max no. result rows (hits)
-    if limit != None:
-        params.update(limit=limit)
-
-    try:
-        response = requests.get('https://www.uniprot.org/uniprot/', params=params)
-        if response.status_code == 200:
-            lines = response.text.splitlines()
-            if len(lines) > 1:
-                # text returned by uniprot api has weird spacing, so clean it
-                col_names = [Preprocessor.sterilize(line) for line in lines[0].split('\t')]
-            for line in lines[1:]:
-                col_vals = line.split('\t')
-                xref = dict(zip(col_names, col_vals))
-                xrefs.append(xref)
-        else:
-            LOGGER.error('Uniprot returned: %i, params: %s', response.status_code, str(params))
-    except requests.exceptions.RequestException as err:
-        logging.error(err)
-
-    return xrefs
-
-def ground(annotation, organisms=(9606), limit=10):
-    """
-    """
     for ent in annotation['ents']:
-        if ent['label'] == 'PRGE':
-            xrefs = _query_uniprot(ent['text'], organisms, limit)
-            ent.update(xrefs=xrefs)
-    return annotation
 
-# TODO try with HGNC rest api
-def _query_hgnc(text):
-    """
-    """
-    return None
+        current_request = '{}{}'.format(request, ent['text'])
+
+        # need to specify entity types for anything but PRGE
+        if ent['label'] == 'CHED':
+            current_request += '&entity_types=-1'
+        elif ent['label'] == 'DISO':
+            current_request += '&entity_types=-26'
+        elif ent['label'] == 'LIVB':
+            current_request += '&entity_types=-2'
+
+        r = requests.get(current_request)
+        response = r.text
+
+        if response:
+            xrefs = []
+            entries = response.split('\n')
+
+            for entry in entries:
+                _, organism_id, entry_id = entry.split('\t')
+
+                xref = {'namespace': 'TODO', 'id': entry_id}
+
+                if int(organism_id) > 0:
+                    xref['organism-id'] = organism_id
+
+                xrefs.append(xref)
+
+            ent.update(xrefs=xrefs)
+
+    return annotation


### PR DESCRIPTION
This pull request implements grounding/entity linking for the major entity classes (Chemicals/Drugs, Disease/Disorder, Species/Living beings, and Proteins/Genes) using the [EXTRACT 2.0 API](https://extract.jensenlab.org/). This is used in place of the grounding system we had previously, which only worked for protein/gene entities.

I tried to model the output format used by REACH as closely as possible. Grounding adds a new field to each item in `ents` (`xrefs`) in the output JSON returned by `Saber.annotate()`. E.g.,

_Without grounding_

```json
{
  "text": "The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.",
  "ents": [
    {
      "start": 23,
      "end": 27,
      "text": "Hdm2",
      "label": "PRGE"
    },
    {
      "start": 31,
      "end": 34,
      "text": "MK2",
      "label": "PRGE"
    },
    {
      "start": 66,
      "end": 69,
      "text": "p53",
      "label": "PRGE"
    }
  ]
}
```

_With grounding_

```json
{
  "text": "The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.",
  "ents": [
    {
      "start": 23,
      "end": 27,
      "text": "Hdm2",
      "label": "PRGE",
      "xrefs": [
        {
          "namespace": "STRING",
          "id": "ENSP00000258149",
          "organism-id": "9606"
        },
        {
          "namespace": "STRING",
          "id": "ENSP00000410769",
          "organism-id": "9606"
        }
      ]
    },
    {
      "start": 31,
      "end": 34,
      "text": "MK2",
      "label": "PRGE",
      "xrefs": [
        {
          "namespace": "STRING",
          "id": "ENSP00000356070",
          "organism-id": "9606"
        },
        {
          "namespace": "STRING",
          "id": "ENSP00000433109",
          "organism-id": "9606"
        }
      ]
    },
    {
      "start": 66,
      "end": 69,
      "text": "p53",
      "label": "PRGE",
      "xrefs": [
        {
          "namespace": "STRING",
          "id": "ENSP00000269305",
          "organism-id": "9606"
        }
      ]
    }
  ]
}
```

Where `namespace` is the external resource the entity is grounded to and `id` is the unique identifier in that external resource. `organism-id` is unique to `PRGE` entities. Currently, this will default to reporting `9606`. The EXTRACT API docs state that a feature is currently being developed that will allow for the automatic detection of organism-id for each protein/gene mention. When / if that gets implemented, I will work it into Saber.

__Usage__

Usage is the same as before. Grounding is _off_ by default as it makes annotation _slightly_ slower

```python
from saber import Saber

saber = Saber()

saber.load('PRGE')

saber.annotate('The phosphorylation of Hdm2 by MK2 promotes the ubiquitination of p53.', ground=True)
```

See the [docs](https://baderlab.github.io/saber/quick_start/#grounding) for more info.

__Issues Closed__

Closes #23.