### PR TITLE
BioBERT

### DIFF
--- a/saber/constants.py
+++ b/saber/constants.py
@@ -30,7 +30,9 @@ START = '<START>'  # start-of-sentence token
 END = '<END>'  # end-of-sentence token
 OUTSIDE = 'O'  # 'outside' tag of the IOB, BIO, and IOBES tag formats
 WORDPIECE = 'X'  # special tag used by BERTs wordpiece tokenizer
-CLASSIFICATION = '[CLS]'  # special tag used by BERTs classifiers
+
+CLS = '[CLS]'  # special BERT classification token
+SEP = '[SEP]'  # special BERT sequence seperator token
 
 # DATA
 RANDOM_STATE = 42  # random seed
@@ -59,6 +61,7 @@ PRETRAINED_MODELS = {
     'PRGE': '1xOmxpgNjQJK8OJSvih9wW5AITGQX6ODT',
     'DISO': '1qmrBuqz75KM57Ug5MiDBfp0d5H3S_5ih',
     'CHED': '13s9wvu3Mc8fG73w51KD8RArA31vsuL1c',
+    'biobert_v1.1_pubmed': '1jI1HyzMzSShjHfeO1pSmw5su8R6p5Vsv'
 }
 # relative path to pre-trained model directory
 PRETRAINED_MODEL_DIR = resource_filename(__name__, 'pretrained_models')
@@ -85,7 +88,7 @@ MODEL_NAMES = ['bilstm-crf-ner', 'bert-ner']
 KERAS = 'keras'
 PYTORCH = 'pytorch'
 # which pre-trained BERT model to use
-PYTORCH_BERT_MODEL = 'bert-base-cased'
+PYTORCH_BERT_MODEL = 'biobert_v1.1_pubmed'
 
 # EXTRACT 2.0 API
 # arguments passed in a get request to the EXTRACT 2.0 API to specify entity type

--- a/saber/models/base_model.py
+++ b/saber/models/base_model.py
@@ -22,10 +22,10 @@ class BaseModel():
     models (list): A list of Keras or PyTorch models.
     """
     def __init__(self, config, datasets, embeddings=None, **kwargs):
-        self.config = config  # hyperparameters and model details
-        self.datasets = datasets  # dataset(s) tied to this instance
-        self.embeddings = embeddings  # pre-trained word embeddings tied to this instance
-        self.model = None  # Keras / PyTorch model tied to this instance
+        self.config = config  # Hyperparameters and model details
+        self.datasets = datasets  # Dataset(s) tied to this instance
+        self.embeddings = embeddings  # Pre-trained word embeddings tied to this instance
+        self.model = None  # Saber model tied to this instance
 
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/saber/saber.py
+++ b/saber/saber.py
@@ -10,7 +10,6 @@ from operator import itemgetter
 from pprint import pprint
 
 import numpy as np
-from google_drive_downloader import GoogleDriveDownloader as gdd
 from keras.models import Model
 from spacy import displacy
 
@@ -260,18 +259,9 @@ class Saber():
             directory = [directory]
 
         for dir_ in directory:
-            # get what might be a pretrained model name
-            pretrained_model = os.path.splitext(dir_)[0].strip().upper()
-
-            # allows user to provide names of pre-trained models (e.g. 'PRGE-base')
-            if pretrained_model in constants.PRETRAINED_MODELS:
-                dir_ = os.path.join(constants.PRETRAINED_MODEL_DIR, pretrained_model)
-                # download model from Google Drive, will skip if already exists
-                file_id = constants.PRETRAINED_MODELS[pretrained_model]
-                dest_path = '{}.tar.bz2'.format(dir_)
-                gdd.download_file_from_google_drive(file_id=file_id, dest_path=dest_path)
-
-                LOGGER.info('Loaded pre-trained model %s from Google Drive', pretrained_model)
+            # If directory is an available pretained model, download it from Google Drive
+            if dir_ in constants.PRETRAINED_MODELS:
+                dir_ = model_utils.download_model_from_gdrive(pretrained_model=dir_)
 
             dir_ = generic_utils.clean_path(dir_)
             generic_utils.extract_directory(dir_)

--- a/saber/tests/conftest.py
+++ b/saber/tests/conftest.py
@@ -425,8 +425,7 @@ def single_base_keras_model_embeddings(dummy_config, dummy_dataset_1, dummy_embe
 def bert_tokenizer():
     """Tokenizer for pre-trained BERT model.
     """
-    bert_tokenizer = BertTokenizer.from_pretrained(constants.PYTORCH_BERT_MODEL,
-                                                   do_lower_case=False)
+    bert_tokenizer = BertTokenizer.from_pretrained('bert-base-cased', do_lower_case=False)
 
     return bert_tokenizer
 

--- a/saber/tests/conftest.py
+++ b/saber/tests/conftest.py
@@ -7,7 +7,9 @@ from ..config import Config
 from ..dataset import Dataset
 from ..embeddings import Embeddings
 from ..metrics import Metrics
+from ..models.base_model import BaseModel
 from ..models.base_model import BaseKerasModel
+from ..models.base_model import BasePyTorchModel
 from ..models.bert_token_classifier import BertTokenClassifier
 from ..models.multi_task_lstm_crf import MultiTaskLSTMCRF
 from ..preprocessor import Preprocessor
@@ -377,6 +379,15 @@ def single_mt_bilstm_model_specify(single_mt_bilstm_model):
 
 
 @pytest.fixture
+def compound_mt_bilstm_model_specify(compound_mt_bilstm_model):
+    """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration file and
+    a single specified model."""
+    compound_mt_bilstm_model.specify()
+
+    return compound_mt_bilstm_model
+
+
+@pytest.fixture
 def single_mt_bilstm_model_embeddings(dummy_config, dummy_dataset_1, dummy_embeddings):
     """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration file and
     loaded embeddings"""
@@ -398,10 +409,40 @@ def single_mt_bilstm_model_embeddings_specify(single_mt_bilstm_model_embeddings)
 
 
 @pytest.fixture
-def single_base_keras_model(dummy_config, dummy_dataset_1, dummy_embeddings):
+def single_base_model(dummy_config, dummy_dataset_1):
+    """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration."""
+    model = BaseModel(config=dummy_config,
+                      datasets=[dummy_dataset_1],
+                      # to test passing of arbitrary keyword args to constructor
+                      totally_arbitrary='arbitrary')
+    return model
+
+
+@pytest.fixture
+def compound_base_model(dummy_config, dummy_dataset_1, dummy_dataset_2):
+    """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration."""
+    model = BaseModel(config=dummy_config,
+                      datasets=[dummy_dataset_1, dummy_dataset_2],
+                      # to test passing of arbitrary keyword args to constructor
+                      totally_arbitrary='arbitrary')
+    return model
+
+
+@pytest.fixture
+def single_base_keras_model(dummy_config, dummy_dataset_1):
     """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration."""
     model = BaseKerasModel(config=dummy_config,
                            datasets=[dummy_dataset_1],
+                           # to test passing of arbitrary keyword args to constructor
+                           totally_arbitrary='arbitrary')
+    return model
+
+
+@pytest.fixture
+def compound_base_keras_model(dummy_config, dummy_dataset_1, dummy_dataset_2):
+    """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration."""
+    model = BaseKerasModel(config=dummy_config,
+                           datasets=[dummy_dataset_1, dummy_dataset_2],
                            # to test passing of arbitrary keyword args to constructor
                            totally_arbitrary='arbitrary')
     return model
@@ -416,6 +457,26 @@ def single_base_keras_model_embeddings(dummy_config, dummy_dataset_1, dummy_embe
                            embeddings=dummy_embeddings,
                            # to test passing of arbitrary keyword args to constructor
                            totally_arbitrary='arbitrary')
+    return model
+
+
+@pytest.fixture
+def single_base_pytorch_model(dummy_config, dummy_dataset_1):
+    """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration."""
+    model = BasePyTorchModel(config=dummy_config,
+                             datasets=[dummy_dataset_1],
+                             # to test passing of arbitrary keyword args to constructor
+                             totally_arbitrary='arbitrary')
+    return model
+
+
+@pytest.fixture
+def compound_base_pytorch_model(dummy_config, dummy_dataset_1, dummy_dataset_2):
+    """Returns an instance of MultiTaskLSTMCRF initialized with the default configuration."""
+    model = BasePyTorchModel(config=dummy_config,
+                             datasets=[dummy_dataset_1, dummy_dataset_2],
+                             # to test passing of arbitrary keyword args to constructor
+                             totally_arbitrary='arbitrary')
     return model
 
 # BERT models

--- a/saber/tests/test_base_model.py
+++ b/saber/tests/test_base_model.py
@@ -1,14 +1,63 @@
 """Any and all unit tests for the BaseKerasModel (saber/models/base_model.py).
 """
+from ..models.base_model import BaseModel
 from ..models.base_model import BaseKerasModel
+from ..models.base_model import BasePyTorchModel
 from .resources.constants import *
+from .. import constants
 
 
-def test_attributes_init_of_single_model(dummy_config, dummy_dataset_1, single_base_keras_model):
-    """Asserts instance attributes are initialized correctly when single `MultiTaskLSTMCRF` model is
+def test_attributes_init_of_single_base_model(dummy_config, dummy_dataset_1, single_base_model):
+    """Asserts instance attributes are initialized correctly when single `BaseModel` model is
+    initialized.
+    """
+    assert isinstance(single_base_model, BaseModel)
+
+    # attributes that are passed to __init__
+    assert single_base_model.config is dummy_config
+    assert single_base_model.datasets[0] is dummy_dataset_1
+    assert single_base_model.embeddings is None
+
+    # other instance attributes
+    assert single_base_model.model is None
+
+    # test that we can pass arbitrary keyword arguments
+    assert single_base_model.totally_arbitrary == 'arbitrary'
+
+
+def test_attributes_init_of_compound_base_model(dummy_config,
+                                                dummy_dataset_1,
+                                                dummy_dataset_2,
+                                                compound_base_model):
+    """Asserts instance attributes are initialized correctly when compound `BaseModel` model is
+    initialized.
+    """
+    assert isinstance(compound_base_model, BaseModel)
+
+    # attributes that are passed to __init__
+    assert compound_base_model.config is dummy_config
+    assert compound_base_model.datasets[0] is dummy_dataset_1
+    assert compound_base_model.datasets[1] is dummy_dataset_2
+    assert compound_base_model.embeddings is None
+
+    # other instance attributes
+    assert compound_base_model.model is None
+
+    # test that we can pass arbitrary keyword arguments
+    assert compound_base_model.totally_arbitrary == 'arbitrary'
+
+
+def test_reset_model(single_base_model):
+    pass
+
+
+def test_attributes_init_of_single_base_keras_model(dummy_config,
+                                                    dummy_dataset_1,
+                                                    single_base_keras_model):
+    """Asserts instance attributes are initialized correctly when single `BaseKerasModel` model is
     initialized without embeddings (`embeddings` attribute is None.)
     """
-    assert isinstance(single_base_keras_model, BaseKerasModel)
+    assert isinstance(single_base_keras_model, (BaseModel, BaseKerasModel))
 
     # attributes that are passed to __init__
     assert single_base_keras_model.config is dummy_config
@@ -17,17 +66,43 @@ def test_attributes_init_of_single_model(dummy_config, dummy_dataset_1, single_b
 
     # other instance attributes
     assert single_base_keras_model.model is None
+    assert single_base_keras_model.framework == constants.KERAS
 
     # test that we can pass arbitrary keyword arguments
     assert single_base_keras_model.totally_arbitrary == 'arbitrary'
 
 
-def test_attributes_init_of_single_model_embeddings(dummy_config, dummy_dataset_1, dummy_embeddings,
+def test_attributes_init_of_compound_base_keras_model(dummy_config,
+                                                      dummy_dataset_1,
+                                                      dummy_dataset_2,
+                                                      compound_base_keras_model):
+    """Asserts instance attributes are initialized correctly when compound `BaseKerasModel` model is
+    initialized without embeddings (`embeddings` attribute is None.)
+    """
+    assert isinstance(compound_base_keras_model, (BaseModel, BaseKerasModel))
+
+    # attributes that are passed to __init__
+    assert compound_base_keras_model.config is dummy_config
+    assert compound_base_keras_model.datasets[0] is dummy_dataset_1
+    assert compound_base_keras_model.datasets[1] is dummy_dataset_2
+    assert compound_base_keras_model.embeddings is None
+
+    # other instance attributes
+    assert compound_base_keras_model.model is None
+    assert compound_base_keras_model.framework == constants.KERAS
+
+    # test that we can pass arbitrary keyword arguments
+    assert compound_base_keras_model.totally_arbitrary == 'arbitrary'
+
+
+def test_attributes_init_of_single_model_embeddings(dummy_config,
+                                                    dummy_dataset_1,
+                                                    dummy_embeddings,
                                                     single_base_keras_model_embeddings):
-    """Asserts instance attributes are initialized correctly when single `MultiTaskLSTMCRF` model is
+    """Asserts instance attributes are initialized correctly when single `BaseKerasModel` model is
     initialized with embeddings (`embeddings` attribute is not None.)
     """
-    assert isinstance(single_base_keras_model_embeddings, BaseKerasModel)
+    assert isinstance(single_base_keras_model_embeddings, (BaseModel, BaseKerasModel))
 
     # attributes that are passed to __init__
     assert single_base_keras_model_embeddings.config is dummy_config
@@ -36,6 +111,51 @@ def test_attributes_init_of_single_model_embeddings(dummy_config, dummy_dataset_
 
     # other instance attributes
     assert single_base_keras_model_embeddings.model is None
+    assert single_base_keras_model_embeddings.framework == constants.KERAS
 
     # test that we can pass arbitrary keyword arguments
     assert single_base_keras_model_embeddings.totally_arbitrary == 'arbitrary'
+
+
+def test_attributes_init_of_single_base_pytorch_model(dummy_config,
+                                                      dummy_dataset_1,
+                                                      single_base_pytorch_model):
+    """Asserts instance attributes are initialized correctly when single `BasePyTorchModel` model is
+    initialized.
+    """
+    assert isinstance(single_base_pytorch_model, (BaseModel, BasePyTorchModel))
+
+    # attributes that are passed to __init__
+    assert single_base_pytorch_model.config is dummy_config
+    assert single_base_pytorch_model.datasets[0] is dummy_dataset_1
+    assert single_base_pytorch_model.embeddings is None
+
+    # other instance attributes
+    assert single_base_pytorch_model.model is None
+    assert single_base_pytorch_model.framework == constants.PYTORCH
+
+    # test that we can pass arbitrary keyword arguments
+    assert single_base_pytorch_model.totally_arbitrary == 'arbitrary'
+
+
+def test_attributes_init_of_compound_base_pytorch_model(dummy_config,
+                                                        dummy_dataset_1,
+                                                        dummy_dataset_2,
+                                                        compound_base_pytorch_model):
+    """Asserts instance attributes are initialized correctly when single `BasePyTorchModel` model is
+    initialized.
+    """
+    assert isinstance(compound_base_pytorch_model, (BaseModel, BasePyTorchModel))
+
+    # attributes that are passed to __init__
+    assert compound_base_pytorch_model.config is dummy_config
+    assert compound_base_pytorch_model.datasets[0] is dummy_dataset_1
+    assert compound_base_pytorch_model.datasets[1] is dummy_dataset_2
+    assert compound_base_pytorch_model.embeddings is None
+
+    # other instance attributes
+    assert compound_base_pytorch_model.model is None
+    assert compound_base_pytorch_model.framework == constants.PYTORCH
+
+    # test that we can pass arbitrary keyword arguments
+    assert compound_base_pytorch_model.totally_arbitrary == 'arbitrary'

--- a/saber/tests/test_bert_for_token_classification.py
+++ b/saber/tests/test_bert_for_token_classification.py
@@ -29,7 +29,6 @@ def test_attributes_init_of_single_model(dummy_config, dummy_dataset_1,
     assert single_bert_token_classifier_model.device.type == 'cpu'
     assert single_bert_token_classifier_model.n_gpus == 0
     assert single_bert_token_classifier_model.pretrained_model_name_or_path == 'bert-base-cased'
-    assert isinstance(single_bert_token_classifier_model.tokenizer, BertTokenizer)
     # test that we can pass arbitrary keyword arguments
     assert single_bert_token_classifier_model.totally_arbitrary == 'arbitrary'
 
@@ -50,8 +49,7 @@ def test_attributes_init_of_single_model_specify(dummy_config, dummy_dataset_1,
     assert single_bert_token_classifier_model_specify.embeddings is None
     assert single_bert_token_classifier_model_specify.device.type == 'cpu'
     assert single_bert_token_classifier_model_specify.n_gpus == 0
-    assert single_bert_token_classifier_model_specify.pretrained_model_name_or_path == \
-        'bert-base-cased'
+    assert single_bert_token_classifier_model_specify.pretrained_model_name_or_path == 'bert-base-cased'
     assert isinstance(single_bert_token_classifier_model_specify.tokenizer, BertTokenizer)
     # test that we can pass arbitrary keyword arguments
     assert single_bert_token_classifier_model_specify.totally_arbitrary == 'arbitrary'

--- a/saber/utils/generic_utils.py
+++ b/saber/utils/generic_utils.py
@@ -47,7 +47,7 @@ def extract_directory(directory):
         head, _ = os.path.split(os.path.abspath(directory))
 
         print('Unzipping...', end=' ', flush=True)
-        unpack_archive('{}.tar.bz2'.format(directory), extract_dir=head)
+        unpack_archive(f'{directory}.tar.bz2', extract_dir=head)
 
 
 def compress_directory(directory):


### PR DESCRIPTION
This pull request adds [BioBERT v1.1](https://github.com/naver/biobert-pretrained/releases/tag/v1.1-pubmed) as the default BERT model in Saber. 

The first time you try to load a BERT-based model, a [PyTorch version of BioBERT v1.1](https://drive.google.com/open?id=1jI1HyzMzSShjHfeO1pSmw5su8R6p5Vsv) will be downloaded from Google Drive and saved in `saber/install/path/saber/pretrained_models`.

__Closes__

Closes #135. Closes #137.
