### PR TITLE
Add support for mixed precision

### DIFF
--- a/saber/metrics.py
+++ b/saber/metrics.py
@@ -260,7 +260,7 @@ class Metrics(object):
 
         Performs a prediction step for the given inputs (`self.training_data[partition]['x']`) and
         targets (`self.training_data[partition]['y']`) using `self.model_`. Returns a dictionary
-        keyed by the task (e.g. 'ner', 'rc').
+        keyed by the task (e.g. 'ner', 're').
 
         Args:
             partition (str): Which partition to perform a prediction step on, must be one of
@@ -298,7 +298,7 @@ class Metrics(object):
             y_true_rc = list(itertools.chain(*y_true_rc))
             y_pred_rc = list(itertools.chain(*y_pred_rc))
 
-            eval_scores['rc'] = self.precision_recall_f1_support_multi_class(y_true=y_true_rc,
+            eval_scores['re'] = self.precision_recall_f1_support_multi_class(y_true=y_true_rc,
                                                                              y_pred=y_pred_rc)
 
         return eval_scores

--- a/saber/models/bert_for_ner.py
+++ b/saber/models/bert_for_ner.py
@@ -246,8 +246,6 @@ class BertForNER(BaseModel):
                             outputs = self.model(**inputs)
                             loss = outputs[0]
 
-                            loss.backward()
-
                             # Loss is a vector of size n_gpus, need to average if more than 1
                             if self.n_gpus > 1:
                                 loss = loss.mean()
@@ -329,6 +327,7 @@ class BertForNER(BaseModel):
                     token_type_ids=token_type_ids,
                     attention_mask=attention_mask,
                     labels=labels,
+                    model_idx=model_idx,
                 )
                 loss, logits = outputs[:2]
 

--- a/saber/tests/conftest.py
+++ b/saber/tests/conftest.py
@@ -360,6 +360,18 @@ def saber_bert_for_ner_mt(dummy_config_compound_dataset):
 
 
 @pytest.fixture
+def saber_bert_for_ner_and_re(dummy_config):
+    """Returns an instance of `Saber` initialized with the dummy config file, a single dataset
+    a Keras model."""
+    dummy_config.dataset_reader = 'conll2004datasetreader'
+    saber = Saber(config=dummy_config)
+    saber.load_dataset(directory=PATH_TO_CONLL2004_DATASET)
+    saber.build(model_name='bert-ner-re')
+
+    return saber
+
+
+@pytest.fixture
 def saber_single_dataset_embeddings(dummy_config):
     """Returns instance of `Saber` initialized with the dummy config file, a single dataset and
     embeddings.

--- a/saber/tests/test_saber.py
+++ b/saber/tests/test_saber.py
@@ -45,32 +45,6 @@ class TestSaber(object):
             with pytest.raises(ValueError):
                 saber_bert_for_ner.annotate(text=test)
 
-    def test_annotate_with_bilstm_crf(self, saber_bert_for_ner):
-        """Asserts that call to `Saber.annotate()` returns the expected results with a single dataset
-        loaded."""
-        test = "This is a simple test. With multiple sentences."
-        expected = {'text': test, 'title': '', 'ents': [],
-                    # TODO (John): This is temp, fixes SpaCy bug.
-                    'settings': {}}
-
-        actual = saber_bert_for_ner.annotate(test)
-        actual['ents'] = []  # wipe the predicted ents as they are stochastic.
-
-        assert expected == actual
-
-    def test_annotate_with_mt_bilstm_crf(self, saber_bert_for_ner_mt):
-        """Asserts that call to `Saber.annotate()` returns the expected results with a single dataset
-        loaded."""
-        test = "This is a simple test. With multiple sentences."
-        expected = {'text': test, 'title': '', 'ents': [],
-                    # TODO (John): This is temp, fixes SpaCy bug.
-                    'settings': {}}
-
-        actual = saber_bert_for_ner_mt.annotate(test)
-        actual['ents'] = []  # wipe the predicted ents as they are stochastic.
-
-        assert expected == actual
-
     def test_annotate_with_bert_for_ner(self, saber_bert_for_ner):
         """Asserts that call to `Saber.annotate()` returns the expected results with a single dataset
         loaded."""
@@ -85,8 +59,8 @@ class TestSaber(object):
         assert expected == actual
 
     def test_annotate_with_bert_for_ner_mt(self, saber_bert_for_ner_mt):
-        """Asserts that call to `Saber.annotate()` returns the expected results with a single dataset
-        loaded."""
+        """Asserts that call to `Saber.annotate()` returns the expected results with a BertForNER
+        model loaded."""
         test = "This is a simple test. With multiple sentences."
         expected = {'text': test, 'title': '', 'ents': [],
                     # TODO (John): This is temp, fixes SpaCy bug.
@@ -96,6 +70,18 @@ class TestSaber(object):
         actual['ents'] = []  # wipe the predicted ents as they are stochastic.
 
         assert expected == actual
+
+    # TODO (John): Implement this when we settle on an interface for annotation
+    def test_annotate_with_bert_for_ner_and_re(self, saber_bert_for_ner_and_re):
+        """Asserts that call to `Saber.annotate()` returns the expected results with a
+        BertForNERAndRE model loaded."""
+        pass
+
+    # TODO (John): Implement this when we get the MT model working
+    def test_annotate_with_bert_for_ner_and_re_mt(self, saber_bert_for_ner_and_re):
+        """Asserts that call to `Saber.annotate()` returns the expected results with a multi-task
+        BertForNERAndRE model loaded."""
+        pass
 
     def test_save_missing_step_exception(self, saber_blank):
         """Asserts that `Saber` object raises a MissingStepException when we try to call `Saber.save()`

--- a/saber/utils/model_utils.py
+++ b/saber/utils/model_utils.py
@@ -169,21 +169,12 @@ def download_model_from_gdrive(pretrained_model, extract=True):
 ####################################################################################################
 
 
-def get_device(model=None):
-    """Places `model` on CUDA device if available, returns PyTorch device, number of available GPUs.
-
-    Returns a PyTorch device and number of available GPUs. If `model` is provided, and a CUDA device
-    is available, the model is placed on the CUDA device. If multiple GPUs are available, the model
-    is parallized with `torch.nn.DataParallel(model)`.
-
-    Args:
-        (Torch.nn.Module): A PyTorch model. If CUDA device is available this function will place the
-        model on the CUDA device with `model.to(device)`. If multiple CUDA devices are available,
-        the model is parallized with `torch.nn.DataParallel(model)`.
+def get_device():
+    """Returns a tuple of (a) PyTorch device(s) ('cpu' or 'cuda'), and number of CUDA devices
+    available.
 
     Returns:
-        A two-tuple containing a PyTorch device ('cpu' or 'cuda'), and number of CUDA devices
-        available.
+        A tuple of (a) PyTorch device(s) ('cpu' or 'cuda'), and number of CUDA devices available.
     """
     n_gpu = 0
 
@@ -191,15 +182,14 @@ def get_device(model=None):
     if torch.cuda.is_available():
         device = torch.device('cuda')
         n_gpu = torch.cuda.device_count()
-        # if model is provided, we place it on the GPU and parallize it (if possible)
-        if model:
-            model.to(device)
-            if n_gpu > 1:
-                model = torch.nn.DataParallel(model)
-        model_names = ', '.join([torch.cuda.get_device_name(i) for i in range(n_gpu)])
-        print('Using CUDA device(s) with name(s): {}.'.format(model_names))
+
+        device_names = ', '.join([torch.cuda.get_device_name(i) for i in range(n_gpu)])
+        LOGGER.info('Using CUDA device(s) with name(s) %s', device_names)
+        print(f'Using CUDA device(s) with name(s): {device_names}.')
     else:
         device = torch.device('cpu')
+
+        LOGGER.info('No GPU available. Using CPU.')
         print('No GPU available. Using CPU.')
 
     return device, n_gpu


### PR DESCRIPTION
This pull request adds support for [mixed-precision training](https://docs.nvidia.com/deeplearning/sdk/mixed-precision-training/index.html) to Saber two models. In short, NVIDIAs AMP library takes care of casting tensors to 16-bit precision, which reduces memory usage and speeds up training. In our case, I am seeing a roughly 23% reduction in training times. 

If `apex` is installed, it is used for mixed-precision training. Otherwise, the model is trained at regular 32-bit precision.

```python
# Use mixed precision training if Apex is available
try:
    from apex import amp
    model, optimizers = amp.initialize(self.model, optimizers, opt_level='O1')
    LOGGER.info("Imported Apex. Training with mixed precision (opt_level='O1').")
except ImportError:
    print(("Install Apex for faster training times and reduced memory usage"
            " (https://github.com/NVIDIA/apex)."))
    LOGGER.info("Couldn't import Apex. Training with standard precision.")
```

Nothing is required from the user beside ensuring `apex` is installed.

### Closes

Closes #160.

### TODOs

- [x] :bug: Why is `BertForNER` throwing an error when `BertForNERAndRE` is not?