### PR TITLE
Removing Keras / Tensorflow dependencies

### DIFF
--- a/saber/metrics.py
+++ b/saber/metrics.py
@@ -1,5 +1,5 @@
 """Contains the Metrics class, which computes, stores, prints and saves performance metrics
-for a Keras model.
+for a Saber model.
 """
 import copy
 import itertools

--- a/saber/preprocessor.py
+++ b/saber/preprocessor.py
@@ -8,7 +8,7 @@ from collections import Counter
 
 import neuralcoref
 import spacy
-from keras.preprocessing.sequence import pad_sequences
+from keras_preprocessing.sequence import pad_sequences
 
 from . import constants
 from .constants import UNK

--- a/saber/tests/conftest.py
+++ b/saber/tests/conftest.py
@@ -2,7 +2,6 @@
 """
 import pytest
 import spacy
-from keras.utils import to_categorical
 from pytorch_transformers import BertTokenizer
 
 from .. import constants
@@ -425,7 +424,7 @@ def dummy_training_data(conll2003datasetreader_load):
         'train': {
             'x': [conll2003datasetreader_load.idx_seq['train']['word'],
                   conll2003datasetreader_load.idx_seq['train']['char']],
-            'y': to_categorical(conll2003datasetreader_load.idx_seq['train']['ent'])
+            'y': conll2003datasetreader_load.idx_seq['train']['ent'],
         },
         'valid': None,
         'test': None,

--- a/saber/utils/bert_utils.py
+++ b/saber/utils/bert_utils.py
@@ -1,5 +1,5 @@
 import torch
-from keras.preprocessing.sequence import pad_sequences
+from keras_preprocessing.sequence import pad_sequences
 from pytorch_transformers.optimization import AdamW
 from torch.utils import data
 

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,10 @@ setuptools.setup(
     ],
     install_requires=[
         'scikit-learn>=0.20.1',
-        'tensorflow>=1.12.0',
         'pytorch-transformers>=1.0.0',
         'Flask>=1.0.2',
         'waitress>=1.1.0',
-        'keras>=2.2.4',
+        'Keras-Preprocessing>=1.1.0',
         'PTable>=0.9.2',
         'seqeval>=0.0.12',
         'spacy==2.1.0',


### PR DESCRIPTION
This pull request is a bit of a stop-gap. The only remaining function we were using from the Keras / Tensorflow libraries was the `pad_sequence` utility. 

I have made `keras_preprocessing` a dependency, which allowed us to drop both `keras` and `tensorflow` as dependencies.