### PR TITLE
Better use of validation split

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -38,9 +38,14 @@ Of course, not all corpora are distributed in the CoNLL format:
 - Corpora in the **Standoff** format can be converted to **CoNLL** format using [this](https://github.com/spyysalo/standoff2conll) tool.
 - Corpora in **PubTator** format can be converted to **Standoff** first using [this](https://github.com/spyysalo/pubtator) tool.
 
-Saber infers the "training strategy" based on the structure of the dataset folder:
+### Partitioning Datasets for Evaluation
 
-- If `valid.*` and/or `test.*` files are provided, they will be used for validation/evaluation respectively.
+Saber infers the _partitioning strategy_ based on the structure of the dataset folder and the arguments `k_folds`, `validation_split`.
+
+- To use k-fold cross-validation, provide only a `train.*` file under `dataset_folder`. Choose the number of folds with the `k_folds` argument. Optionally, specify a proportion of examples to hold-out at random in each fold as a validation set with `validation_split`.
+- To create a validation split from the train set, provide a `train.*` file (and optionally, a `test.*` file) under `dataset_folder` and specify the proportion of training examples to hold-out for a validation set with `validation_split`.
+
+Otherwise, provide the partitions yourself with the files `train.*`, `valid.*` and `test.*` under `dataset_folder` and leave `k_folds` and `validation_split` equal to `0`.
 
 E.g.
 
@@ -52,12 +57,8 @@ E.g.
 │   └── test.tsv
 ```
 
-- Otherwise, to use k-fold cross-validation, simply provide a `train.*` file in your dataset folder and specify the number of folds with `k_folds`
-- To create a validation split from your `train.*` file instead, specify the size of the split with `validation_split`.
-
 !!! note
-      If no `valid.*` file is provided and `k_folds > 0 and validation_split > 0`, `k_folds` will take precedence.
-
+      `k_folds` will be ignored if either a `valid.*` or `test.*` file is found under `dataset_folder`. Both arguments `k_folds` and `validation_split` will be ignored if a `valid.*` file is found under `dataset_folder`. 
 
 ## Word embeddings
 

--- a/saber/models/bert_for_ner.py
+++ b/saber/models/bert_for_ner.py
@@ -144,7 +144,7 @@ class BertForNER(BaseModel):
             # Re-process the dataset to be compatible with BERT models
             processed_dataset = bert_utils.process_dataset_for_bert(dataset, self.tokenizer)
             # If no valid set provide, create one from the train set (or generate k-folds)
-            processed_dataset = data_utils.get_validation_set(self.config, processed_dataset)
+            processed_dataset = data_utils.prepare_data_for_eval(self.config, processed_dataset)
 
             # A hack to ensure that training data is always a list (datasets) of lists (folds)
             if not isinstance(processed_dataset, list):

--- a/saber/models/bert_for_ner_and_re.py
+++ b/saber/models/bert_for_ner_and_re.py
@@ -162,7 +162,7 @@ class BertForNERAndRE(BaseModel):
             # Re-process the dataset to be compatible with BERT models
             processed_dataset = bert_utils.process_dataset_for_bert(dataset, self.tokenizer)
             # If no valid set provide, create one from the train set (or generate k-folds)
-            processed_dataset = data_utils.get_validation_set(self.config, processed_dataset)
+            processed_dataset = data_utils.prepare_data_for_eval(self.config, processed_dataset)
 
             # A hack to ensure that training data is always a list (datasets) of lists (folds)
             if not isinstance(processed_dataset, list):

--- a/saber/tests/conftest.py
+++ b/saber/tests/conftest.py
@@ -430,8 +430,7 @@ def dummy_training_data(conll2003datasetreader_load):
         'test': None,
     }
 
-    # A list of lists which represents data for each fold (inner list) of each dataset (outer list)
-    return [[training_data]]
+    return training_data
 
 
 ####################################################################################################
@@ -580,7 +579,8 @@ def dummy_metrics(dummy_config,
     """
     metrics = Metrics(config=dummy_config,
                       model_=bert_for_ner_specify,
-                      training_data=dummy_training_data,
+                      # list of lists represents data for each fold of each dataset
+                      training_data=[[dummy_training_data]],
                       idx_to_tag=conll2003datasetreader_load.idx_to_tag,
                       output_dir=dummy_output_dir[0],
                       model_idx=0,

--- a/saber/tests/test_base_model.py
+++ b/saber/tests/test_base_model.py
@@ -9,7 +9,10 @@ from ..models.base_model import BaseModel
 class TestBaseModel(object):
     """Collects all unit tests for `saber.models.base_model.BaseModel`.
     """
-    def test_initialization(self, dummy_config, conll2003datasetreader_load, base_model):
+    def test_attributes_after_initilization(self,
+                                            dummy_config,
+                                            conll2003datasetreader_load,
+                                            base_model):
         """Asserts instance attributes are initialized correctly when single `BaseModel` model is
         initialized.
         """
@@ -23,11 +26,11 @@ class TestBaseModel(object):
         # Other instance attributes
         assert base_model.model is None
 
-    def test_initialization_mt(self,
-                               dummy_config_compound_dataset,
-                               conll2003datasetreader_load,
-                               dummy_dataset_2,
-                               base_model_mt):
+    def test_attributes_after_initilization_mt(self,
+                                               dummy_config_compound_dataset,
+                                               conll2003datasetreader_load,
+                                               dummy_dataset_2,
+                                               base_model_mt):
         """Asserts instance attributes are initialized correctly when compound `BaseModel` model is
         initialized.
         """

--- a/saber/tests/test_bert_for_ner.py
+++ b/saber/tests/test_bert_for_ner.py
@@ -23,7 +23,10 @@ from ..models.modules.bert_for_token_classification_multi_task import \
 class TestBertForNER(object):
     """Collects all unit tests for `saber.models.bert_for_ner.BertForNER`.
     """
-    def test_initialization(self, dummy_config, conll2003datasetreader_load, bert_for_ner):
+    def test_attributes_after_initilization(self,
+                                            dummy_config,
+                                            conll2003datasetreader_load,
+                                            bert_for_ner):
         """Asserts instance attributes are as expected after initialization of a `BertForNER` model.
         """
         assert isinstance(
@@ -51,11 +54,11 @@ class TestBertForNER(object):
 
         assert bert_for_ner.model_name == 'bert-ner'
 
-    def test_initialization_mt(self,
-                               dummy_config_compound_dataset,
-                               conll2003datasetreader_load,
-                               dummy_dataset_2,
-                               bert_for_ner_mt):
+    def test_attributes_after_initilization_mt(self,
+                                               dummy_config_compound_dataset,
+                                               conll2003datasetreader_load,
+                                               dummy_dataset_2,
+                                               bert_for_ner_mt):
         """Asserts instance attributes are as expected after initialization of a multi-task
         `BertForNER` model.
         """

--- a/saber/tests/test_bert_for_ner_and_re.py
+++ b/saber/tests/test_bert_for_ner_and_re.py
@@ -24,10 +24,10 @@ from ..models.modules.bert_for_entity_and_relation_extraction import \
 class TestBertForNERAndRE(object):
     """Collects all unit tests for `saber.models.bert_for_ner_and_re.BertForNERAndRE`.
     """
-    def test_initialization(self,
-                            dummy_config,
-                            conll2004datasetreader_load,
-                            bert_for_ner_and_re):
+    def test_attributes_after_initilization(self,
+                                            dummy_config,
+                                            conll2004datasetreader_load,
+                                            bert_for_ner_and_re):
         """Asserts instance attributes are as expected after initialization of a
         `BertForNERAndRE` model.
         """
@@ -58,10 +58,10 @@ class TestBertForNERAndRE(object):
         assert bert_for_ner_and_re.pretrained_model_name_or_path == 'bert-base-cased'
         assert bert_for_ner_and_re.model_name == 'bert-ner-re'
 
-    def test_initialization_mt(self,
-                               dummy_config,
-                               conll2004datasetreader_load,
-                               bert_for_ner_and_re):
+    def test_attributes_after_initilization_mt(self,
+                                               dummy_config,
+                                               conll2004datasetreader_load,
+                                               bert_for_ner_and_re):
         """Asserts instance attributes are as expected after initialization of a multi-task
         `BertForNERAndRE` model.
         """

--- a/saber/tests/test_data_utils.py
+++ b/saber/tests/test_data_utils.py
@@ -117,3 +117,52 @@ class TestDataUtils(object):
 
         assert all(dummy_dataset_2.type_to_idx[type_] == source_type_to_idx[type_]
                    for type_ in ['word', 'char'])
+
+    # TODO (John): This should check data directly instead of just looking at lens. Also,
+    # we need additional tests for when validation_split > 0.
+    def test_get_k_folds_no_validation_split(self, dummy_training_data):
+        """Asserts that the correct number of training examples exist in each fold after a call
+        to `data_utils.get_k_folds()`.
+        """
+        k_folds = 2
+        actual = data_utils.get_k_folds(training_data=dummy_training_data, k_folds=k_folds)
+
+        # Check that we created 2 folds
+        assert len(actual) == k_folds
+
+        # Check that the expected partitions exist with the correct number of training examples
+        for fold in actual:
+            # Train
+            assert len(fold['train']['x'][0]) == 1
+            assert len(fold['train']['x'][1]) == 1
+            assert len(fold['train']['y']) == 1
+
+            # Test
+            assert len(fold['test']['x'][0]) == 1
+            assert len(fold['test']['x'][1]) == 1
+            assert len(fold['test']['y']) == 1
+
+            # Valid
+            assert not fold['valid']
+
+    # TODO (John): This should check data directly instead of just looking at lens.
+    def test_get_validation_split(self, dummy_training_data):
+        """Asserts that the correct number of training examples exist in each fold after a call
+        to `data_utils.get_k_folds()`.
+        """
+        actual = data_utils.get_validation_split(training_data=dummy_training_data,
+                                                 validation_split=0.5)
+
+        # Check that the expected partitions exist with the correct number of training examples
+        # Train
+        assert len(actual['train']['x'][0]) == 1
+        assert len(actual['train']['x'][1]) == 1
+        assert len(actual['train']['y']) == 1
+
+        # Valid
+        assert len(actual['valid']['x'][0]) == 1
+        assert len(actual['valid']['x'][1]) == 1
+        assert len(actual['valid']['y']) == 1
+
+        # Test
+        assert not actual['test']

--- a/saber/tests/test_data_utils.py
+++ b/saber/tests/test_data_utils.py
@@ -166,3 +166,31 @@ class TestDataUtils(object):
 
         # Test
         assert not actual['test']
+
+    # TODO (John): This should check data directly instead of just looking at lens.
+    # we need additional tests for when validation_split > 0.
+    def test_prepare_data_for_eval_k_folds(self, dummy_config, dummy_training_data):
+        """Asserts that the correct number of training examples exist in each fold after a call
+        to `data_utils.get_k_folds()`.
+        """
+        dummy_config.k_folds = 2
+        actual = data_utils.prepare_data_for_eval(config=dummy_config,
+                                                  training_data=dummy_training_data)
+
+        # Check that we created 2 folds
+        assert len(actual) == dummy_config.k_folds
+
+        # Check that the expected partitions exist with the correct number of training examples
+        for fold in actual:
+            # Train
+            assert len(fold['train']['x'][0]) == 1
+            assert len(fold['train']['x'][1]) == 1
+            assert len(fold['train']['y']) == 1
+
+            # Test
+            assert len(fold['test']['x'][0]) == 1
+            assert len(fold['test']['x'][1]) == 1
+            assert len(fold['test']['y']) == 1
+
+            # Valid
+            assert not fold['valid']

--- a/saber/tests/test_embeddings.py
+++ b/saber/tests/test_embeddings.py
@@ -16,8 +16,9 @@ from .resources.constants import PATH_TO_DUMMY_EMBEDDINGS
 class TestEmbeddings(object):
     """Collects all unit tests for `saber.utils.bert_utils`.
     """
-    def test_initialization(self, dummy_embeddings_before_load):
-        """Asserts that Embeddings object contains the expected attribute values after initialization.
+    def test_attributes_after_initilization(self, dummy_embeddings_before_load):
+        """Asserts that Embeddings object contains the expected attribute values after
+        initialization.
         """
         # test attributes whos values are passed to the constructor
         assert dummy_embeddings_before_load.filepath == PATH_TO_DUMMY_EMBEDDINGS

--- a/saber/tests/test_metrics.py
+++ b/saber/tests/test_metrics.py
@@ -25,7 +25,7 @@ class TestMetrics(object):
         # attributes that are passed to __init__
         assert dummy_metrics.config is dummy_config
         assert dummy_metrics.model_ is bert_for_ner_specify
-        assert dummy_metrics.training_data is dummy_training_data
+        assert dummy_metrics.training_data[0][0] is dummy_training_data
         assert dummy_metrics.idx_to_tag is conll2003datasetreader_load.idx_to_tag
         assert dummy_metrics.output_dir == dummy_output_dir[0]
         # other instance attributes

--- a/saber/utils/data_utils.py
+++ b/saber/utils/data_utils.py
@@ -328,7 +328,7 @@ def prepare_data_for_eval(config, training_data):
         If `training_data['valid'] is None and `training_data['test'] is None and config.k_folds`:
             Returns a list containing copies of `training_data`, each partitioned into train and
             test paritions (`training_data['train'], `training_data['test']), for `k_folds` folds of
-            cross-validation, created by splitting `training_data['train']`. 
+            cross-validation, created by splitting `training_data['train']`.
         If `training_data['valid'] is not None and `training_data['test'] is None
             and `config.k_folds` and `config.validation_split`:
             Returns a list containing copies of `training_data`, each partitioned into train and


### PR DESCRIPTION
## Overview

Previously, only one of `k_folds` or `validation_split` could be used, with `k_folds` taking precedence over `validation_split`. Now, they can be used together.

- To use k-fold cross-validation, provide only a `train.*` file under `dataset_folder`. Choose the number of folds with the `k_folds` argument. Optionally, specify a proportion of examples to hold-out at random in each fold as a validation set with `validation_split`.
- To create a validation split from the train set, provide a `train.*` file (and optionally, a `test.*` file) under `dataset_folder` and specify the proportion of training examples to hold-out for a validation set with `validation_split`.

Otherwise, provide the partitions yourself with the files `train.*`, `valid.*` and `test.*` under `dataset_folder` and leave `k_folds` and `validation_split` equal to `0`.

E.g.

```bash
.
├── NCBI_Disease
│   └── train.tsv
│   └── valid.tsv
│   └── test.tsv
```

> `k_folds` will be ignored if either a `valid.*` or `test.*` file is found under `dataset_folder`. Both arguments `k_folds` and `validation_split` will be ignored if a `valid.*` file is found under `dataset_folder`. 

### TODOs

- [x] Update tests for this new functionality.
- [x] Update docs to reflect this new scheme

### Closes

Closes #154.