### PR TITLE
Implement transformer

### DIFF
--- a/saber/constants.py
+++ b/saber/constants.py
@@ -102,9 +102,9 @@ PRETRAINED_MODELS = {
 
 # Batch size to use when performing model prediction
 PRED_BATCH_SIZE = 256
-# Max length of a sentence
+# Max length of a sentence, set to None to use the length of the longest sentence
 MAX_SENT_LEN = 256
-# Max length of a character sequence (word)
+# Max length of a character sequence (word), set to None to use the length of the longest word
 MAX_CHAR_LEN = 25
 
 # Possible models

--- a/saber/models/bert_for_ner_and_re.py
+++ b/saber/models/bert_for_ner_and_re.py
@@ -206,11 +206,15 @@ class BertForNERAndRE(BaseModel):
         # Training loop
         k_folds = len(training_data[0])
         for fold in range(k_folds):
-            # Use mixed precision training if Apex is available
+            # Use mixed precision training if Apex is installed and CUDA device available
             try:
-                from apex import amp
-                model, optimizers = amp.initialize(self.model, optimizers, opt_level='O1')
-                LOGGER.info("Imported Apex. Training with mixed precision (opt_level='O1').")
+                if self.device == 'cuda':
+                    from apex import amp
+                    model, optimizers = amp.initialize(self.model, optimizers, opt_level='O1')
+                    LOGGER.info("Imported Apex. Training with mixed precision (opt_level='O1').")
+                else:
+                    LOGGER.info(('Apex is installed but no CUDA device is available. Training with'
+                                 ' standard precision.'))
             except ImportError:
                 print(("Install Apex for faster training times and reduced memory usage"
                        " (https://github.com/NVIDIA/apex)."))
@@ -284,12 +288,12 @@ class BertForNERAndRE(BaseModel):
                             try:
                                 with amp.scale_loss(loss, optimizer) as scaled_loss:
                                     scaled_loss.backward()
-                                torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer), 1.0)
-                            except (ImportError, UnboundLocalError) as e:
+                                torch.nn.utils.clip_grad_norm_(amp.master_params(optimizer),
+                                                               self.config.grad_norm)
+                            except (ImportError, UnboundLocalError):
                                 loss.backward()
-                                torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
-
-                                LOGGER.error(e)
+                                torch.nn.utils.clip_grad_norm_(self.model.parameters(),
+                                                               self.config.grad_norm)
 
                             # Track train loss
                             train_ner_loss[model_idx] += ner_loss

--- a/saber/tests/test_bert_utils.py
+++ b/saber/tests/test_bert_utils.py
@@ -5,7 +5,6 @@ from pytorch_transformers.optimization import AdamW
 from torch.utils.data import RandomSampler
 from torch.utils.data import SequentialSampler
 
-from .. import constants
 from ..constants import CLS
 from ..constants import MAX_SENT_LEN
 from ..constants import PAD
@@ -61,10 +60,10 @@ class TestBertUtils(object):
 
         # Check shape instead of content, as content is checked in different unit tests
         for partition in conll2003datasetreader_load.dataset_folder:
-            assert actual[partition]['x'][0].size() == (2, constants.MAX_SENT_LEN)
-            assert actual[partition]['x'][1].size() == (2, constants.MAX_SENT_LEN)
-            assert actual[partition]['y'].size() == (2, constants.MAX_SENT_LEN)
-            assert actual[partition]['orig_to_tok_map'].size() == (2, constants.MAX_SENT_LEN)
+            assert actual[partition]['x'][0].size() == (2, MAX_SENT_LEN)
+            assert actual[partition]['x'][1].size() == (2, MAX_SENT_LEN)
+            assert actual[partition]['y'].size() == (2, MAX_SENT_LEN)
+            assert actual[partition]['orig_to_tok_map'].size() == (2, MAX_SENT_LEN)
             # This is a CoNLL2003 formatted dataset so there should be no rel labels
             assert 'rel_labels' not in actual[partition]
 
@@ -83,10 +82,10 @@ class TestBertUtils(object):
 
         # Check shape instead of content, as content is checked in different unit tests
         for partition in conll2004datasetreader_load.dataset_folder:
-            assert actual[partition]['x'][0].size() == (3, constants.MAX_SENT_LEN)
-            assert actual[partition]['x'][1].size() == (3, constants.MAX_SENT_LEN)
-            assert actual[partition]['y'].size() == (3, constants.MAX_SENT_LEN)
-            assert actual[partition]['orig_to_tok_map'].size() == (3, constants.MAX_SENT_LEN)
+            assert actual[partition]['x'][0].size() == (3, MAX_SENT_LEN)
+            assert actual[partition]['x'][1].size() == (3, MAX_SENT_LEN)
+            assert actual[partition]['y'].size() == (3, MAX_SENT_LEN)
+            assert actual[partition]['orig_to_tok_map'].size() == (3, MAX_SENT_LEN)
             assert actual[partition]['rel_labels'] == \
                 conll2004datasetreader_load.idx_seq[partition]['rel']
 
@@ -125,7 +124,7 @@ class TestBertUtils(object):
         )
 
         # Just check for shape, as token indicies will depend on specific BERT model used
-        assert actual_indexed_tokens.shape == (2, constants.MAX_SENT_LEN)
+        assert actual_indexed_tokens.shape == (2, MAX_SENT_LEN)
         assert torch.equal(expected_orig_to_tok_map, actual_orig_to_tok_map)
         assert torch.equal(attention_mask, actual_attention_mask)
 
@@ -150,7 +149,7 @@ class TestBertUtils(object):
         )
 
         # Just check for shape, as token indicies will depend on specific BERT model used
-        assert actual_indexed_tokens.shape == (2, constants.MAX_SENT_LEN)
+        assert actual_indexed_tokens.shape == (2, MAX_SENT_LEN)
         assert torch.equal(expected_orig_to_tok_map, actual_orig_to_tok_map)
         assert torch.equal(attention_mask, actual_attention_mask)
         assert torch.equal(expected_indexed_labels, actual_indexed_labels)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,10 @@ envlist =
 [testenv]
 # Unit tests don't expect a CUDA device to be available
 setenv = CUDA_VISIBLE_DEVICES = ''
-commands = pytest --cov=saber --cov-config .coveragerc -vv
+commands = 
+    # Hotfix, see: https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-311411559
+    export BOTO_CONFIG=/dev/null
+    pytest --cov=saber --cov-config .coveragerc -vv
 deps =
 	pytest
 	pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,13 @@ envlist =
 	py
 
 [testenv]
-# Unit tests don't expect a CUDA device to be available
-setenv = CUDA_VISIBLE_DEVICES = ''
-commands = 
-    # Hotfix, see: https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-311411559
-    export BOTO_CONFIG=/dev/null
-    pytest --cov=saber --cov-config .coveragerc -vv
+
+setenv = 
+    # Hotfix, see: https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-496091279
+    BOTO_CONFIG = /dev/null
+    # Unit tests don't expect a CUDA device to be available
+    CUDA_VISIBLE_DEVICES = ''
+commands = pytest --cov=saber --cov-config .coveragerc -vv
 deps =
 	pytest
 	pytest-cov


### PR DESCRIPTION
## Overview

This pull request adds the missing transformer encoder layer to our joint NER + RE model ✨.  

Right now, the number of attention heads and the number of encoder layers are both hardcoded at 2. In future pull requests, these will be added to the config file and we will include them in our hyperparameter search to determine the best default values.

## Additional Changes

Trying to train on a CPU with Apex caused an error. This has been fixed by requiring both Apex and an available GPU before defaulting to mixed-precision training.

## Closes

Closes #167.