### PR TITLE
Fix random seeds

### DIFF
--- a/saber/__init__.py
+++ b/saber/__init__.py
@@ -1,10 +1,20 @@
 import logging
 import os
+import random
 from datetime import datetime
 
+import numpy as np
+import torch
+
+from .config import Config
+from .constants import RANDOM_STATE
 # Make Saber, the interface for the entire package, importable from root
 from .saber import Saber
-from .config import Config
+
+# Fix random seeds
+random.seed(RANDOM_STATE)
+np.random.seed(RANDOM_STATE)
+torch.manual_seed(RANDOM_STATE)
 
 # If applicable, delete the existing log file to generate a fresh log file during each execution
 try:


### PR DESCRIPTION
Quick PR to fix all random seeds. 

The random seed is chosen with `saber.constants.RANDOM_STATE` (`42` by default). This value is used to seed the random number generators of pythons `random` module, `numpy`, and `torch`.

This will allow us to run multiple trials with different random seeds and then average them.