### PR TITLE
Faster att mask gen

### DIFF
--- a/saber/models/bert_for_ner_and_re.py
+++ b/saber/models/bert_for_ner_and_re.py
@@ -255,7 +255,7 @@ class BertForNERAndRE(BaseModel):
                     dynamic_ncols=True
                 )
 
-                for step, batches in enumerate(pbar):
+                for _, batches in enumerate(pbar):
                     for batch in batches:
                         if batch is not None:
                             (batch_indices, input_ids, attention_mask, ent_labels, orig_to_tok_map,
@@ -282,8 +282,7 @@ class BertForNERAndRE(BaseModel):
                                 ner_loss = ner_loss.mean()
                                 re_loss = re_loss.mean()
 
-                            delay_coef = 1 if epoch else step / len(dataloaders[0])
-                            loss = ner_loss + delay_coef * re_loss
+                            loss = ner_loss + re_loss
 
                             try:
                                 with amp.scale_loss(loss, optimizer) as scaled_loss:
@@ -309,7 +308,6 @@ class BertForNERAndRE(BaseModel):
                                 'NER_loss': f'{train_ner_loss[model_idx] / train_steps[model_idx]:.4f}',
                                 'RE_loss': f'{train_re_loss[model_idx] / train_steps[model_idx]:.4f}',
                                 'joint_loss': f'{train_loss_joint[model_idx] / train_steps[model_idx]:.4f}',
-                                'delay_coef': f'{delay_coef:.2f}'
                             }
                             pbar.set_postfix(postfix)
 

--- a/saber/models/modules/bert_for_entity_and_relation_extraction.py
+++ b/saber/models/modules/bert_for_entity_and_relation_extraction.py
@@ -103,7 +103,7 @@ class BertForEntityAndRelationExtraction(BertPreTrainedModel):
         self.dropout = nn.Dropout(config.dropout_rate)
         self.ent_classifier = nn.Linear(config.hidden_size, self.num_ent_labels)
 
-        self.apply(self.init_weights)
+        self.init_weights()
 
         # RE module
         # TODO (John): Once I settle on some kind of structure of hyperparams (a dict?) place

--- a/saber/models/modules/bert_for_token_classification_multi_task.py
+++ b/saber/models/modules/bert_for_token_classification_multi_task.py
@@ -89,7 +89,7 @@ class BertForTokenClassificationMultiTask(BertPreTrainedModel):
             [nn.Linear(config.hidden_size, nl) for nl in self.num_labels]
         )
 
-        self.apply(self.init_weights)
+        self.init_weights()
 
     def forward(self, input_ids, token_type_ids=None, attention_mask=None, labels=None,
                 position_ids=None, head_mask=None, model_idx=-1):

--- a/saber/tests/test_bert_utils.py
+++ b/saber/tests/test_bert_utils.py
@@ -39,7 +39,7 @@ tag_to_idx = {
 attention_mask = torch.as_tensor([
     [1.] * len(bert_tokens[0]) + [0.] * (MAX_SENT_LEN - len(bert_tokens[0])),
     [1.] * len(bert_tokens[1]) + [0.] * (MAX_SENT_LEN - len(bert_tokens[1])),
-])
+], dtype=torch.long)
 
 
 class TestBertUtils(object):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
     install_requires=[
         'scikit-learn>=0.20.1',
         'torch>=1.2.0',
-        'pytorch-transformers>=1.1.0',
+        'pytorch-transformers>=1.2.0',
         'Flask>=1.0.2',
         'waitress>=1.1.0',
         'Keras-Preprocessing>=1.1.0',


### PR DESCRIPTION
## Overview

This PR is a combination of a few things, just rolled them into one as we are rushing toward the ICLR deadline.

1. Replaces list comprehensions used to generate attention masks with `torch.where`. This is many times faster.
2. Remove the transformer layer. It was accounting for almost no performance (and actually hurting performance in some cases).
3. Clean up the optimizer initialization code. It is now better written to prevent weight decay being applied to normalization layers.

> Something funky happen and I had to push the same commits twice.