### PR TITLE
Implements entity pre-training

### DIFF
--- a/saber/models/bert_for_ner_and_re.py
+++ b/saber/models/bert_for_ner_and_re.py
@@ -255,7 +255,7 @@ class BertForNERAndRE(BaseModel):
                     dynamic_ncols=True
                 )
 
-                for _, batches in enumerate(pbar):
+                for step, batches in enumerate(pbar):
                     for batch in batches:
                         if batch is not None:
                             (batch_indices, input_ids, attention_mask, ent_labels, orig_to_tok_map,
@@ -282,7 +282,10 @@ class BertForNERAndRE(BaseModel):
                                 ner_loss = ner_loss.mean()
                                 re_loss = re_loss.mean()
 
-                            loss = ner_loss + re_loss
+                            # Implements entity pre-training using a linear weighting on the re loss
+                            # objective for the first epoch only.
+                            delay_coef = 1 if epoch else step / total
+                            loss = ner_loss + delay_coef * re_loss
 
                             try:
                                 with amp.scale_loss(loss, optimizer) as scaled_loss:


### PR DESCRIPTION
## Overview

This PR implements entity pre-training. Simply put, entity pre-training involves pre-training the entity module before training the entire NER + RE model jointly.

Previously, we were implementing this by delaying the training of the RE module by a full epoch. I have found a different yet equally simple technique that works quite well. Basically, the loss function is weighted according to

```python
loss = ner_loss + decay_coef * re_loss
```

where `0 <= delay_coef <= 1` and is computed as  `current_step / total_steps` if this is the first epoch, or `1` otherwise. I saw gains up to 1% on the validation set using this scheme.